### PR TITLE
FEAT allow custom fragment types

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -36,7 +36,11 @@ library_prediction:
     - 200
     - 2000
   nce: 25.0
-  instrument: QE
+  # semicolon separated list of fragment types. Supported types are: a, b, c, x, y, z, b_modloss, y_modloss
+  fragment_types: 'b;y'
+  # maximum charge state for predicted fragments
+  max_fragment_charge: 2
+  instrument: Lumos
   save_hdf: True
   checkpoint_folder_path: None
 

--- a/alphadia/planning.py
+++ b/alphadia/planning.py
@@ -190,6 +190,7 @@ class Plan:
 
         if self.config["library_prediction"]["predict"]:
             logger.progress("Predicting library properties.")
+
             pept_deep_prediction = libtransform.PeptDeepPrediction(
                 use_gpu=self.config["general"]["use_gpu"],
                 fragment_mz=self.config["library_prediction"]["fragment_mz"],
@@ -198,6 +199,12 @@ class Plan:
                 mp_process_num=self.config["general"]["thread_count"],
                 checkpoint_folder_path=self.config["library_prediction"][
                     "checkpoint_folder_path"
+                ],
+                fragment_types=self.config["library_prediction"][
+                    "fragment_types"
+                ].split(";"),
+                max_fragment_charge=self.config["library_prediction"][
+                    "max_fragment_charge"
                 ],
             )
 

--- a/gui/workflows/PeptideCentric.v1.json
+++ b/gui/workflows/PeptideCentric.v1.json
@@ -203,6 +203,20 @@
                     "type": "float_range"
                 },
                 {
+                    "id": "fragment_types",
+                    "name": "Fragment types",
+                    "value": "b;y",
+                    "description": "Semicolon separated list of fragment types. \n Supported types: b, y, b_modloss, y_modloss. \n Must be supported by the chosen PeptDeep model.",
+                    "type": "string"
+                },
+                {
+                    "id": "max_fragment_charge",
+                    "name": "Maximum fragment charge",
+                    "value": 2,
+                    "description": "Fragments will be generated up to this charge state. Must be supported by the chosen PeptDeep model.",
+                    "type": "integer"
+                },
+                {
                     "id": "nce",
                     "name": "Normalized collision energy",
                     "value": 25.0,


### PR DESCRIPTION
This PR allows to set other fragment types and charges than `b,y` for PeptDeep library prediction. 
For example it allows to set `b_modloss;y_modloss` for phospho search.