### PR TITLE
Pip cache and concurrency

### DIFF
--- a/.github/workflows/fdr_performance.yml
+++ b/.github/workflows/fdr_performance.yml
@@ -5,6 +5,10 @@ on:
 
 name: FDR performance test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   loose_installation:
     name: Loose pip installation

--- a/.github/workflows/performance_testing.yml
+++ b/.github/workflows/performance_testing.yml
@@ -6,6 +6,10 @@ on:
 
 name: performance testing
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   TEST_DATA_DIR: C:\actions-runner\_data
   CONDA: C:\Users\wallmann\Miniconda3

--- a/.github/workflows/pip_installation.yml
+++ b/.github/workflows/pip_installation.yml
@@ -5,6 +5,10 @@ on:
 
 name: Default installation and tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #stable_installation:
   #  name: Test stable pip installation on ${{ matrix.os }}


### PR DESCRIPTION
Chore: use pip caching and stop running actions on new pushes, both measures to safe time and resources.

This brings me to question: should we add these kinds of changes (also pre-commit,  etc) also to alphabase? @jalew188 @GeorgWa ?