### PR TITLE
Fix logger issue

### DIFF
--- a/alphadia/cli.py
+++ b/alphadia/cli.py
@@ -316,13 +316,13 @@ def run(*args, **kwargs):
     for f in raw_path_list:
         logger.progress(f"  {os.path.basename(f)}")
 
-    logger.progress(f"Using library: {library_path}.")
+    logger.progress(f"Using library: {library_path}")
 
     logger.progress(f"Using {len(fasta_path_list)} fasta files:")
     for f in fasta_path_list:
         logger.progress(f"  {f}")
 
-    logger.progress(f"Saving output to {output_directory}.")
+    logger.progress(f"Saving output to: {output_directory}")
 
     try:
         import matplotlib

--- a/alphadia/cli.py
+++ b/alphadia/cli.py
@@ -2,6 +2,8 @@
 
 # native imports
 import logging
+import sys
+
 import yaml
 import os
 import re
@@ -345,3 +347,4 @@ def run(*args, **kwargs):
 
         logger.info(traceback.format_exc())
         logger.error(e)
+        sys.exit(1)

--- a/alphadia/planning.py
+++ b/alphadia/planning.py
@@ -125,10 +125,8 @@ class Plan:
 
         # set log level
         level_to_set = self.config["general"]["log_level"]
-        if (level_code := logging.getLevelNamesMapping().get(level_to_set)) is None:
-            logger.error(f"Setting logging to unknown level {level_to_set}")
-        else:
-            logger.setLevel(level_code)
+        level_code = logging.getLevelName(level_to_set)
+        logger.setLevel(level_code)
 
         self.load_library()
 


### PR DESCRIPTION
- Fixes the followiung issue on python < 3.11:
```
0:00:00.027515 INFO:                 │   └──mobility_observed 
0:00:00.027580 INFO:                 └──output_columns
0:00:00.027647 INFO:                     └──mobility_calibrated 
0:00:00.029549 INFO: Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/alphadia/cli.py", line 333, in run
    plan = Plan(
  File "/usr/local/lib/python3.9/site-packages/alphadia/planning.py", line 128, in __init__
    if (level_code := logging.getLevelNamesMapping().get(level_to_set)) is None:
AttributeError: module 'logging' has no attribute 'getLevelNamesMapping'

0:00:00.029638 ERROR: module 'logging' has no attribute 'getLevelNamesMapping'
```

`getLevelNamesMapping` is available for python >=3.11 only.

 Note that I also changed the behaviour: if the requested log level is not available, an error is raised. Alternatively, one could just continue with the default level.

- exit on error with a nonzero exit code
- fix a little flaw that filenames in log output had a trailing dot