### PR TITLE
Add conda to docu

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+changelog:
+  exclude:
+#    labels:
+#      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Other Changes / unlabeled
+      labels:
+        - "*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,4 @@ repos:
   hooks:
     - id: ruff-format
     - id: ruff
+      args: [ '--fix' ]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,3 +35,4 @@ You can run the checks yourself using:
 ```bash
 pre-commit run --all-files
 ```
+Make sure you use the same version of pre-commit as defined in `requirements_development.txt`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,7 +1,13 @@
 # Contributing
 This document gathers information on how to contribute to the alphaDIA project.
 
-## Release a new version
+## Release process
+### Tagging of changes
+In order to have release notes automatically generated, changes need to be tagged with labels.
+The following labels are used (should be safe-explanatory):
+`breaking-change`, `bug`, `enhancement`.
+
+### Release a new version
 Note: Releases need to be done from the `main` branch.
 
 1. Bump the version locally to (e.g. to `X.Y.Z`) and merge the change to `main`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,4 +1,5 @@
 # Contributing
+This document gathers information on how to contribute to the alphaDIA project.
 
 ## Release a new version
 Note: Releases need to be done from the `main` branch.
@@ -13,3 +14,18 @@ You need to specify the commit to release, and the release tag (e.g. `vX.Y.Z`).
 specifying the release tag (e.g. `vX.Y.Z`).
 6. Run the [Publish Docker Image](https://github.com/MannLabs/alphadia/actions/workflows/publish_docker_image.yml) workflow,
 specifying the release tag (e.g. `vX.Y.Z`).
+
+
+## Notes for developers
+### pre-commit hooks
+It is highly recommended to use the provided pre-commit hooks, as the CI pipeline enforces all checks therein to
+pass in order to merge a branch.
+
+The hooks need to be installed once by
+```bash
+pre-commit install
+```
+You can run the checks yourself using:
+```bash
+pre-commit run --all-files
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -104,6 +104,8 @@ Install all frontend packages using npm
 cd gui
 npm install
 ```
+Note that this gui install only works if the conda environment is called "`alphadia`",
+unless the "envName" variables in `profile.js` are adjusted.
 
 The GUI can then be started by typing
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -63,7 +63,9 @@ Finally, run `alphadia -v` to check if the installation was successful;
 ## Developer installation
 AlphaDIA can be installed in editable (i.e. developer) mode. This allows to fully customize the software and even modify the source code to your specific needs. When an editable Python package is installed, its source code is stored in a location of your choice.
 
-Make sure you have an conda environment and Mono installed for reading `.raw` files as described [here](https://github.com/MannLabs/alpharaw#installation).
+Make sure you have a conda environment and Mono installed for reading `.raw` files as described [here](https://github.com/MannLabs/alpharaw#installation).
+
+See also the [developer guide](contributing.md) for more information on how to contribute to alphaDIA.
 
 ### 1. Setting up the repository
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,10 +30,20 @@ you can install alphaDIA via `pip`.
 Please make sure you have a valid installation of conda or miniconda.
 We recommend setting up miniconda as described on their [website](https://docs.conda.io/projects/miniconda/en/latest/).
 
-If you want to use `.raw` files on Thermo instruments alphaRaw is required, which depends on Mono. A detailed guide to installing alphaRaw with mono can be found [here](https://github.com/MannLabs/alpharaw#installation).
+If you want to use `.raw` files on Thermo instruments alphaRaw is required, which depends on Mono.
+A detailed guide to installing alphaRaw with mono can be found [here](https://github.com/MannLabs/alpharaw#installation), a short version is given
+[below](#2-installing-mono).
 
 ### 2. Setting up the environment
 
+It is highly recommended to use a conda environment for the installation of alphaDIA.
+This ensures that all dependencies are installed correctly and do not interfere with other packages.
+```bash
+conda create -n alphadia python=3.11
+conda activate alphadia
+```
+
+### 3. Installing alphaDIA
 Finally, alphaDIA and all its dependencies can be installed by
 ```bash
 pip install "alphadia[stable]"
@@ -72,6 +82,7 @@ git pull
 ```
 
 ### 2. Installation: backend
+Set up a conda environment and activate it as described [here](#2-setting-up-the-environment).
 
 Use pip to install alphaDIA, using the `development` tag to install additional packages required for development only
 ```bash
@@ -149,9 +160,13 @@ docker run -v $DATA_FOLDER:/app/data/ --rm alphadia-docker
 ## Slurm cluster Installation
 
 ### 1. Set up environment
+Check if conda is available on your cluster. If not, install it, or, if provided, load the corresponding module, e.g.
+`module load anaconda/3/2023.03`.
+
 Create and activate a new conda environment
 ```bash
-conda create -n alpha
+conda create -n alphadia python=3.11
+conda activate alphadia
 ```
 ### 2. Installing mono
 Install mono to support reading proprietary vendor formats like Thermo `.raw` files.

--- a/gui/src/main/modules/profile.js
+++ b/gui/src/main/modules/profile.js
@@ -9,16 +9,16 @@ const Profile = class {
     config = {
         "version": "1.7.0",
         "conda": {
-            "envName": "alpha",
+            "envName": "alphadia",
             "path": ""
         },
         "clippy": false,
         "WSLExecutionEngine": {
-            "envName": "alpha",
+            "envName": "alphadia",
 
         },
         "CMDExecutionEngine": {
-            "envName": "alpha",
+            "envName": "alphadia",
             "condaPath": ""
         },
         "BundledExecutionEngine": {

--- a/misc/pip_install.sh
+++ b/misc/pip_install.sh
@@ -13,5 +13,5 @@ else
 fi
 
 # conda 'run' vs. 'activate', cf. https://stackoverflow.com/a/72395091
-conda run -n $ENV_NAME --no-capture-output pip install --no-cache-dir -e "../.$INSTALL_STRING"
+conda run -n $ENV_NAME --no-capture-output pip install -e "../.$INSTALL_STRING"
 conda run -n $ENV_NAME --no-capture-output alphadia -v


### PR DESCRIPTION
- add commands on how to create conda env to docs,
- revert not using pip cache in gh actions
- add pre-commit to docs
- add release template