### PR TITLE
#230: ruff rule B905: add strict keyword to zip

### DIFF
--- a/alphadia/calibration/property.py
+++ b/alphadia/calibration/property.py
@@ -420,7 +420,7 @@ class Calibration:
                 s=1,
             )
 
-            for ax, dim in zip(axs[input_property, :], [0, 2]):
+            for ax, dim in zip(axs[input_property, :], [0, 2], strict=True):
                 ax.set_xlabel(self.input_columns[input_property])
                 ax.set_ylabel(f"observed deviation {transform_unit}")
 

--- a/alphadia/fdrexperimental.py
+++ b/alphadia/fdrexperimental.py
@@ -438,7 +438,7 @@ class BinaryClassifier(Classifier):
                 )
 
                 for batch_start, batch_stop in zip(
-                    test_batch_start_list, test_batch_stop_list
+                    test_batch_start_list, test_batch_stop_list, strict=True
                 ):
                     batch_x_test = x_test[batch_start:batch_stop]
                     batch_y_test = y_test[batch_start:batch_stop]
@@ -804,7 +804,9 @@ class BinaryClassifierLegacy(Classifier):
             y_train = torch.Tensor(y_train[order])
 
             for batch_x, batch_y in zip(
-                x_train.split(self.batch_size), y_train.split(self.batch_size)
+                x_train.split(self.batch_size),
+                y_train.split(self.batch_size),
+                strict=True,
             ):
                 y_pred = self.network(batch_x)
                 loss_value = loss(y_pred, batch_y)
@@ -1126,7 +1128,9 @@ class BinaryClassifierLegacyNewBatching(Classifier):
             batch_start_list = batch_start_list[order]
             batch_stop_list = batch_stop_list[order]
 
-            for batch_start, batch_stop in zip(batch_start_list, batch_stop_list):
+            for batch_start, batch_stop in zip(
+                batch_start_list, batch_stop_list, strict=True
+            ):
                 x_train_batch = x_train[batch_start:batch_stop]
                 y_train_batch = y_train[batch_start:batch_stop]
                 y_pred = self.network(x_train_batch)

--- a/alphadia/features.py
+++ b/alphadia/features.py
@@ -22,7 +22,7 @@ def center_of_mass(
     scans, frames = np.nonzero(single_dense_representation > 0)
     if len(scans) == 0:
         return 0, 0
-    for scan, frame in zip(scans, frames):
+    for scan, frame in zip(scans, frames, strict=True):
         intensity = single_dense_representation[scan, frame]
         intensity_accumulation += intensity
         frame_accumulation += frame * intensity
@@ -73,7 +73,7 @@ def weighted_center_of_mass(
     if len(scans) == 0:
         return 0, 0, 0, 0
 
-    for scan, frame in zip(scans, frames):
+    for scan, frame in zip(scans, frames, strict=True):
         intensity.append(single_dense_representation[scan, frame])
 
     intensity_arr = np.array(intensity)[1:]
@@ -146,7 +146,7 @@ def weighted_center_mean(single_dense_representation, scan_center, frame_center)
     if len(scans) == 0:
         return 0
 
-    for scan, frame in zip(scans, frames):
+    for scan, frame in zip(scans, frames, strict=True):
         value = single_dense_representation[scan, frame]
         distance = np.sqrt((scan - scan_center) ** 2 + (frame - frame_center) ** 2)
         weight = np.exp(-0.1 * distance)
@@ -458,7 +458,7 @@ def build_features(
     # create weight matrix to exclude empty isotopes
     i, j = np.nonzero(observed_precursor_mz == 0)
     precursor_weights = isotope_intensity.copy()
-    for i_, j_ in zip(i, j):
+    for i_, j_ in zip(i, j, strict=True):
         precursor_weights[i_, j_] = 0
 
     observed_precursor_intensity = weighted_center_mean_2d(

--- a/alphadia/grouping.py
+++ b/alphadia/grouping.py
@@ -35,7 +35,7 @@ def group_and_parsimony(
 
     # reshape precursor indices and ids into a dictionary of ids linked to sets of precursors
     id_dict = {}
-    for precursor, ids in zip(precursor_idx, precursor_ids):
+    for precursor, ids in zip(precursor_idx, precursor_ids, strict=True):
         for id in ids.split(";"):
             if id not in id_dict:
                 id_dict[id] = set()
@@ -99,7 +99,7 @@ def group_and_parsimony(
     # order by precursor index and return as lists
     # TODO look above, order by precursor_idx directly?
     return_dict_ordered = {key: return_dict[key] for key in precursor_idx}
-    ids, groups = zip(*return_dict_ordered.values())
+    ids, groups = zip(*return_dict_ordered.values(), strict=True)
 
     return ids, groups
 

--- a/alphadia/numba/fragments.py
+++ b/alphadia/numba/fragments.py
@@ -331,9 +331,7 @@ def get_ion_group_mapping(
 
     score_group_intensity = np.zeros((len(ion_mz)), dtype=np.float32)
 
-    for precursor, mz, intensity in zip(
-        ion_precursor, ion_mz, ion_intensity, strict=True
-    ):
+    for precursor, mz, intensity in zip(ion_precursor, ion_mz, ion_intensity):  # noqa: B905
         # score_group_idx = precursor_group[precursor]
 
         if len(grouped_mz) == 0 or np.abs(grouped_mz[-1] - mz) > EPSILON:

--- a/alphadia/numba/fragments.py
+++ b/alphadia/numba/fragments.py
@@ -331,7 +331,7 @@ def get_ion_group_mapping(
 
     score_group_intensity = np.zeros((len(ion_mz)), dtype=np.float32)
 
-    for precursor, mz, intensity in zip(ion_precursor, ion_mz, ion_intensity):  # noqa: B905
+    for precursor, mz, intensity in zip(ion_precursor, ion_mz, ion_intensity):  # noqa: B905 ('strict' not supported by numba yet)
         # score_group_idx = precursor_group[precursor]
 
         if len(grouped_mz) == 0 or np.abs(grouped_mz[-1] - mz) > EPSILON:

--- a/alphadia/numba/fragments.py
+++ b/alphadia/numba/fragments.py
@@ -331,7 +331,9 @@ def get_ion_group_mapping(
 
     score_group_intensity = np.zeros((len(ion_mz)), dtype=np.float32)
 
-    for precursor, mz, intensity in zip(ion_precursor, ion_mz, ion_intensity):
+    for precursor, mz, intensity in zip(
+        ion_precursor, ion_mz, ion_intensity, strict=True
+    ):
         # score_group_idx = precursor_group[precursor]
 
         if len(grouped_mz) == 0 or np.abs(grouped_mz[-1] - mz) > EPSILON:

--- a/alphadia/outputaccumulator.py
+++ b/alphadia/outputaccumulator.py
@@ -543,7 +543,13 @@ def ms2_quality_control(
     fragment_correlation_df = spec_lib_base._fragment_correlation_df
 
     for i, (start_idx, stop_idx) in tqdm(
-        enumerate(zip(precursor_df["frag_start_idx"], precursor_df["frag_stop_idx"]))
+        enumerate(
+            zip(
+                precursor_df["frag_start_idx"],
+                precursor_df["frag_stop_idx"],
+                strict=True,
+            )
+        )
     ):
         # get XIC correlations and intensities for the precursor
         fragment_correlation_view = fragment_correlation_df.iloc[start_idx:stop_idx]

--- a/alphadia/outputtransform.py
+++ b/alphadia/outputtransform.py
@@ -720,7 +720,7 @@ class SearchPlanOutput:
         group_nice_list.append("pg")
 
         # IMPORTANT: 'pg' has to be the last group in the list as this will be reused
-        for group, group_nice in zip(group_list, group_nice_list):
+        for group, group_nice in zip(group_list, group_nice_list, strict=True):
             logger.progress(
                 f"Performing label free quantification on the {group_nice} level"
             )

--- a/alphadia/peakgroup/search.py
+++ b/alphadia/peakgroup/search.py
@@ -689,7 +689,7 @@ def build_candidates(
     cycle_limits_list = np.zeros((peak_cycle_list.shape[0], 2), dtype="int32")
 
     for candidate_rank, (scan_relative, cycle_relative) in enumerate(
-        zip(peak_scan_list, peak_cycle_list)
+        zip(peak_scan_list, peak_cycle_list, strict=True)
     ):
         scan_limits_relative, cycle_limits_relative = numeric.symetric_limits_2d(
             score,
@@ -739,6 +739,7 @@ def build_candidates(
         peak_score_list,
         scan_limits_list,
         cycle_limits_list,
+        strict=True,
     ):
         # does not work anymore
 
@@ -907,6 +908,7 @@ class HybridCandidateSelection:
                         "frame_stop",
                     ],
                     candidate_container.to_candidate_df(),
+                    strict=True,
                 )
             }
         )

--- a/alphadia/peakgroup/search.py
+++ b/alphadia/peakgroup/search.py
@@ -689,7 +689,7 @@ def build_candidates(
     cycle_limits_list = np.zeros((peak_cycle_list.shape[0], 2), dtype="int32")
 
     for candidate_rank, (scan_relative, cycle_relative) in enumerate(
-        zip(peak_scan_list, peak_cycle_list, strict=True)
+        zip(peak_scan_list, peak_cycle_list)  # noqa: B905 ('strict' not supported by numba yet)
     ):
         scan_limits_relative, cycle_limits_relative = numeric.symetric_limits_2d(
             score,

--- a/alphadia/plexscoring.py
+++ b/alphadia/plexscoring.py
@@ -1823,7 +1823,12 @@ class CandidateScoring:
             "charge",
         ]
         df = pd.DataFrame(
-            {key: value for value, key in zip(psm_proto_df.to_fragment_df(), colnames)}
+            {
+                key: value
+                for value, key in zip(
+                    psm_proto_df.to_fragment_df(), colnames, strict=True
+                )
+            }
         )
 
         # join precursor columns

--- a/alphadia/transferlearning/train.py
+++ b/alphadia/transferlearning/train.py
@@ -401,7 +401,7 @@ class FinetuneManager(ModelManager):
             The normalized fragment intensity dataframe.
         """
         for start, stop in zip(
-            precursor_df["frag_start_idx"], precursor_df["frag_stop_idx"]
+            precursor_df["frag_start_idx"], precursor_df["frag_stop_idx"], strict=True
         ):
             iloc_slice = fragment_intensity_df.iloc[start:stop, :]
             max_intensity = np.max(iloc_slice.values.flatten())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,5 +79,4 @@ select =  [
 ignore = [
     "E501",  # Line too long  (ruff wraps code, but not docstrings)
     "B028",  #  No explicit `stacklevel` keyword argument found (for warnings)
-    "B905"  # TODO revisit: `zip()` without an explicit `strict=` parameter
 ]

--- a/tests/e2e_tests/calc_metrics.py
+++ b/tests/e2e_tests/calc_metrics.py
@@ -144,6 +144,7 @@ def _basic_plot(df: pd.DataFrame, test_case: str, metric: str, metric_std: str =
         df["sys/creation_time"],
         df["branch_name"],
         df["short_sha"],
+        strict=True,
     ):
         fmt = "%Y-%m-%d %H:%M:%S.%f"
         dt = datetime.strptime(str(x), fmt)


### PR DESCRIPTION
As discussed: use "strict=True" for all* zips.

*except the one in the njit-decorated method