### PR TITLE
CHORE: raise on output error

### DIFF
--- a/alphadia/planning.py
+++ b/alphadia/planning.py
@@ -381,7 +381,7 @@ class Plan:
 
         except Exception as e:
             logger.error(f"Output failed with error {e}", exc_info=True)
-            return
+            raise e
 
         logger.progress("=================== Search Finished ===================")
 


### PR DESCRIPTION
fix the issue that exit code =0 although an error occured..

```
0:15:43.095419 ERROR: Output failed with error 'precursor_idx'
Traceback (most recent call last):
  File "/fs/gpfs41/lv07/fileset03/home/b_mann/kraken/src/alphadia/alphadia/planning.py", line 380, in run
    output.build(workflow_folder_list, base_spec_lib)
  File "/fs/gpfs41/lv07/fileset03/home/b_mann/kraken/src/alphadia/alphadia/outputtransform.py", line 362, in build
    psm_df = self.build_precursor_table(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fs/gpfs41/lv07/fileset03/home/b_mann/kraken/src/alphadia/alphadia/outputtransform.py", line 531, in build_precursor_table
    psm_df = psm_df.merge(
             ^^^^^^^^^^^^^
  File "/fs/home/kraken/conda-envs/alphadia-1.7.0-dev/lib/python3.11/site-packages/pandas/core/frame.py", line 10832, in merge
    return merge(
           ^^^^^^
  File "/fs/home/kraken/conda-envs/alphadia-1.7.0-dev/lib/python3.11/site-packages/pandas/core/reshape/merge.py", line 170, in merge
    op = _MergeOperation(
         ^^^^^^^^^^^^^^^^
  File "/fs/home/kraken/conda-envs/alphadia-1.7.0-dev/lib/python3.11/site-packages/pandas/core/reshape/merge.py", line 794, in __init__
    ) = self._get_merge_keys()
        ^^^^^^^^^^^^^^^^^^^^^^
  File "/fs/home/kraken/conda-envs/alphadia-1.7.0-dev/lib/python3.11/site-packages/pandas/core/reshape/merge.py", line 1310, in _get_merge_keys
    left_keys.append(left._get_label_or_level_values(lk))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fs/home/kraken/conda-envs/alphadia-1.7.0-dev/lib/python3.11/site-packages/pandas/core/generic.py", line 1911, in _get_label_or_level_values
    raise KeyError(key)
KeyError: 'precursor_idx'
0:16:01.389283 WARNING: WARNING: Temp mmap arrays were written to /tmp/temp_mmap_dsqmm0qb. Cleanup of this folder is OS dependant, and might need to be triggered manually! Current space: 34,274,779,136
Removed 0 of 1 files.
EXIT CODE:
0
```