### PR TITLE
BUG: fix issue with zip strict & numba

### DIFF
--- a/alphadia/numba/fragments.py
+++ b/alphadia/numba/fragments.py
@@ -331,7 +331,7 @@ def get_ion_group_mapping(
 
     score_group_intensity = np.zeros((len(ion_mz)), dtype=np.float32)
 
-    for precursor, mz, intensity in zip(ion_precursor, ion_mz, ion_intensity):  # noqa: B905 ('strict' not supported by numba yet)
+    for precursor, mz, intensity in zip(ion_precursor, ion_mz, ion_intensity):  # noqa: B905 ('strict' not supported by numba yet
         # score_group_idx = precursor_group[precursor]
 
         if len(grouped_mz) == 0 or np.abs(grouped_mz[-1] - mz) > EPSILON:

--- a/alphadia/peakgroup/search.py
+++ b/alphadia/peakgroup/search.py
@@ -739,8 +739,7 @@ def build_candidates(
         peak_score_list,
         scan_limits_list,
         cycle_limits_list,
-        strict=True,
-    ):
+    ):  # noqa: B905 ('strict' not supported by numba yet)
         # does not work anymore
 
         scan_limits_absolute = numeric.wrap1(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,4 +79,5 @@ select =  [
 ignore = [
     "E501",  # Line too long  (ruff wraps code, but not docstrings)
     "B028",  #  No explicit `stacklevel` keyword argument found (for warnings)
+    "B905"  # This causes problems in numba code: `zip()` without an explicit `strict=` parameter
 ]


### PR DESCRIPTION
fix issues with numba and zip

for future reference: (non-complete) error message
```
Traceback (most recent call last):
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/site-packages/numba/core/dispatcher.py", line 442, in _compile_for_args
    raise e
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/site-packages/numba/core/dispatcher.py", line 375, in _compile_for_args
    return_val = self.compile(tuple(argtypes))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/site-packages/numba/core/dispatcher.py", line 905, in compile
Exception in thread Thread-15 (numba_func_parallel):
Traceback (most recent call last):
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
    cres = self._compiler.compile(args, return_type)
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/site-packages/numba/core/dispatcher.py", line 442, in _compile_for_args
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/site-packages/numba/core/dispatcher.py", line 80, in compile
    raise e
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/site-packages/numba/core/dispatcher.py", line 375, in _compile_for_args
    status, retval = self._compile_cached(args, return_type)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/site-packages/numba/core/dispatcher.py", line 94, in _compile_cached
    return_val = self.compile(tuple(argtypes))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/site-packages/numba/core/dispatcher.py", line 905, in compile
Exception in thread Thread-16 (numba_func_parallel):
Traceback (most recent call last):
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/fs/home/wallmann/conda-envs/alpha/lib/python3.11/threading.py", line 982, in run
    retval = self._compile_core(args, return_type)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fs/home/wa
```