### PR TITLE
#261 install MANIFEST.in in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY docs docs
 COPY gui gui
 COPY requirements requirements
 COPY alphadia alphadia
+COPY MANIFEST.in MANIFEST.in
 
 RUN pip install  --no-cache-dir ".[stable]"
 


### PR DESCRIPTION
This is a PR for bug #261 . It installs the MANIFEST.in file in the docker container, which allows the pip install command to include all the files in the alphadia source directory, including the default configuration yaml, not just the .py files.