### PR TITLE
Fix loose tests and Docker issues

### DIFF
--- a/.github/workflows/e2e_testing.yml
+++ b/.github/workflows/e2e_testing.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Conda info
         shell: bash -el {0}
         run: conda info
-      - name: Pip installation with loose dependencies
+      - name: Pip installation with stable dependencies
+        id: pip_installation
         shell: bash -el {0}
         run: |
           cd misc
@@ -41,3 +42,8 @@ jobs:
         shell: bash -el {0}
         run: |
           conda remove -n $RUN_NAME --all
+      - name: Delete Caches on Error
+        if: steps.pip_installation.outcome == 'failure'
+        run: |
+          rm -rf ~/.cache/pip
+          rm -rf ~/.cache/conda

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # https://github.com/michaelosthege/pythonnet-docker
-FROM --platform=linux/amd64 mosthege/pythonnet:python3.9.16-mono6.12-pythonnet3.0.1
+FROM --platform=linux/amd64 mosthege/pythonnet:python3.10.10-mono6.12-pythonnet3.0.1
 
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/misc/pip_install.sh
+++ b/misc/pip_install.sh
@@ -12,6 +12,9 @@ else
   INSTALL_STRING="[${INSTALL_TYPE}]"
 fi
 
+# print pip environment for reproducibility
+conda run -n $ENV_NAME --no-capture-output pip freeze
+
 # conda 'run' vs. 'activate', cf. https://stackoverflow.com/a/72395091
 conda run -n $ENV_NAME --no-capture-output pip install -e "../.$INSTALL_STRING"
 conda run -n $ENV_NAME --no-capture-output alphadia -v

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,4 +18,5 @@ directlfq==0.2.19
 pythonnet==3.0.3
 zstandard==0.22.0
 # not direct dependencies but we have to restrict the versions
+numpy<2 # test: tolerate_version avoid the breaking change in numpy >= 2
 scipy==1.12.0

--- a/requirements/requirements_loose.txt
+++ b/requirements/requirements_loose.txt
@@ -16,4 +16,5 @@ transformers<=4.40.2 # test: tolerate_version
 directlfq
 pythonnet
 zstandard
+numpy<2 # avoid the breaking change in numpy >= 2
 scipy>=1.12.0 # test: tolerate_version

--- a/requirements/requirements_loose.txt
+++ b/requirements/requirements_loose.txt
@@ -16,5 +16,5 @@ transformers<=4.40.2 # test: tolerate_version
 directlfq
 pythonnet
 zstandard
-numpy<2 # avoid the breaking change in numpy >= 2
+numpy<2 # test: tolerate_version avoid the breaking change in numpy >= 2
 scipy>=1.12.0 # test: tolerate_version


### PR DESCRIPTION
Following the good old "one thing per PR rule":
- fix numpy version to <2 to make loose version functional and adapt test
- bump python version to 3.10 in Dockerfile
- delete cache of e2e runner on failure
- add pip freeze to CI output