### PR TITLE
Multiplex spectral library

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -163,23 +163,32 @@ library_multiplexing:
   # if true, the library is multiplexed
   enabled: False
 
+  # if the input library already contains multiplexed channels, the input channel has to be specified.
+  input_channel: 0
+
   # define channels by their name and how modifications should be translated from the input library to the multiplexed library
-  multiplex_mapping:
-    0:
-      mTRAQ@K: mTRAQ@K
-      mTRAQ@Any_N-term: mTRAQ@Any_N-term
+  # channels can be either a number or a string
+  # for every channel, the library gets copied and the modifications are translated according to the mapping
+  # the following example shows how to multiplex mTRAQ to three sample channels and a decoy channel
+  multiplex_mapping: {}
 
-    4:
-      mTRAQ@K: mTRAQ:13C(3)15N(1)@K
-      mTRAQ@Any_N-term: mTRAQ:13C(3)15N(1)@Any_N-term
+    #0:
+    #  mTRAQ@K: mTRAQ@K
+    #  mTRAQ@Any_N-term: mTRAQ@Any_N-term
 
-    8:
-      mTRAQ@K: mTRAQ:13C(6)15N(2)@K
-      mTRAQ@Any_N-term: mTRAQ:13C(6)15N(2)@Any_N-term
+    #4:
+    #  mTRAQ@K: mTRAQ:13C(3)15N(1)@K
+    #  mTRAQ@Any_N-term: mTRAQ:13C(3)15N(1)@Any_N-term
 
-    12:
-      mTRAQ@K: mTRAQ:d12@K
-      mTRAQ@Any_N-term: mTRAQ:d12@Any_N-term
+    #8:
+    #  mTRAQ@K: mTRAQ:13C(6)15N(2)@K
+    #  mTRAQ@Any_N-term: mTRAQ:13C(6)15N(2)@Any_N-term
+
+    #12:
+    #  mTRAQ@K: mTRAQ:d12@K
+    #  mTRAQ@Any_N-term: mTRAQ:d12@Any_N-term
+
+
 
 multiplexing:
   enabled: False

--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -158,6 +158,29 @@ scoring_config:
   precursor_mz_tolerance: 10
   fragment_mz_tolerance: 15
 
+# perform non-isobaric multiplexing of any input library
+library_multiplexing:
+  # if true, the library is multiplexed
+  enabled: False
+
+  # define channels by their name and how modifications should be translated from the input library to the multiplexed library
+  multiplex_mapping:
+    0:
+      mTRAQ@K: mTRAQ@K
+      mTRAQ@Any_N-term: mTRAQ@Any_N-term
+
+    4:
+      mTRAQ@K: mTRAQ:13C(3)15N(1)@K
+      mTRAQ@Any_N-term: mTRAQ:13C(3)15N(1)@Any_N-term
+
+    8:
+      mTRAQ@K: mTRAQ:13C(6)15N(2)@K
+      mTRAQ@Any_N-term: mTRAQ:13C(6)15N(2)@Any_N-term
+
+    12:
+      mTRAQ@K: mTRAQ:d12@K
+      mTRAQ@Any_N-term: mTRAQ:d12@Any_N-term
+
 multiplexing:
   enabled: False
   target_channels: '4,8'

--- a/alphadia/planning.py
+++ b/alphadia/planning.py
@@ -247,6 +247,15 @@ class Plan:
         )
         spectral_library = harmonize_pipeline(spectral_library)
 
+        if self.config["library_multiplexing"]["enabled"]:
+            multiplexing = libtransform.MultiplexLibrary(
+                multiplex_mapping=self.config["library_multiplexing"][
+                    "multiplex_mapping"
+                ],
+                input_channel=self.config["library_multiplexing"]["input_channel"],
+            )
+            spectral_library = multiplexing(spectral_library)
+
         library_path = os.path.join(self.output_folder, "speclib.hdf")
         logger.info(f"Saving library to {library_path}")
         spectral_library.save_hdf(library_path)


### PR DESCRIPTION
Allow automated multiplexing of spectral library from the config.yaml using a config:
```
# perform non-isobaric multiplexing of any input library
library_multiplexing:
  # if true, the library is multiplexed
  enabled: False

  # define channels by their name and how modifications should be translated from the input library to the multiplexed library
  multiplex_mapping:
    0:
      mTRAQ@K: mTRAQ@K
      mTRAQ@Any_N-term: mTRAQ@Any_N-term

    4:
      mTRAQ@K: mTRAQ:13C(3)15N(1)@K
      mTRAQ@Any_N-term: mTRAQ:13C(3)15N(1)@Any_N-term

    8:
      mTRAQ@K: mTRAQ:13C(6)15N(2)@K
      mTRAQ@Any_N-term: mTRAQ:13C(6)15N(2)@Any_N-term

    12:
      mTRAQ@K: mTRAQ:d12@K
      mTRAQ@Any_N-term: mTRAQ:d12@Any_N-term
```