### PR TITLE
FEAT enable selection of alternative peptdeep models

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -48,6 +48,9 @@ library_prediction:
   # set path for custom peptdeep model. If set to null, the default model will be used
   peptdeep_model_path: null
 
+  # set peptdeep model type. Possible values are 'generic', 'phospho', 'digly'. If set to null, the generic model will be used
+  peptdeep_model_type: null
+
 # define custom alphabase modifications not part of unimod or alphabase
 # also used for decoy channels
 custom_modififcations:

--- a/alphadia/libtransform.py
+++ b/alphadia/libtransform.py
@@ -281,7 +281,8 @@ class PeptDeepPrediction(ProcessingStep):
             Path to a folder containing PeptDeep models. If not provided, the default models will be used.
 
         peptdeep_model_type : str, optional
-            Use other peptdeep models provided by the peptdeep model manager. Default is None.
+            Use other peptdeep models provided by the peptdeep model manager.
+            Default is None, which means the peptdeep default model ("generic") is being used.
             Possible values are ['generic','phospho','digly']
 
         fragment_types : List[str], optional
@@ -320,6 +321,7 @@ class PeptDeepPrediction(ProcessingStep):
 
         model_mgr = ModelManager(device=device)
 
+        # will load other model than default generic
         if self.peptdeep_model_type is not None:
             logging.info(f"Loading PeptDeep models of type {self.peptdeep_model_type}")
             model_mgr.load_installed_models(self.peptdeep_model_type)

--- a/alphadia/libtransform.py
+++ b/alphadia/libtransform.py
@@ -253,6 +253,7 @@ class PeptDeepPrediction(ProcessingStep):
         nce: int = 25,
         instrument: str = "Lumos",
         peptdeep_model_path: str | None = None,
+        peptdeep_model_type: str | None = None,
         fragment_types: list[str] | None = None,
         max_fragment_charge: int = 2,
     ) -> None:
@@ -279,6 +280,10 @@ class PeptDeepPrediction(ProcessingStep):
         peptdeep_model_path : str, optional
             Path to a folder containing PeptDeep models. If not provided, the default models will be used.
 
+        peptdeep_model_type : str, optional
+            Use other peptdeep models provided by the peptdeep model manager. Default is None.
+            Possible values are ['generic','phospho','digly']
+
         fragment_types : List[str], optional
             Fragment types to predict. Default is ["b", "y"].
 
@@ -296,6 +301,7 @@ class PeptDeepPrediction(ProcessingStep):
         self.instrument = instrument
         self.mp_process_num = mp_process_num
         self.peptdeep_model_path = peptdeep_model_path
+        self.peptdeep_model_type = peptdeep_model_type
 
         self.fragment_types = fragment_types
         self.max_fragment_charge = max_fragment_charge
@@ -313,6 +319,11 @@ class PeptDeepPrediction(ProcessingStep):
         device = utils.get_torch_device(self.use_gpu)
 
         model_mgr = ModelManager(device=device)
+
+        if self.peptdeep_model_type is not None:
+            logging.info(f"Loading PeptDeep models of type {self.peptdeep_model_type}")
+            model_mgr.load_installed_models(self.peptdeep_model_type)
+
         if self.peptdeep_model_path is not None:
             if not os.path.exists(self.peptdeep_model_path):
                 raise ValueError(

--- a/alphadia/planning.py
+++ b/alphadia/planning.py
@@ -226,6 +226,9 @@ class Plan:
                 peptdeep_model_path=self.config["library_prediction"][
                     "peptdeep_model_path"
                 ],
+                peptdeep_model_type=self.config["library_prediction"][
+                    "peptdeep_model_type"
+                ],
                 fragment_types=self.config["library_prediction"][
                     "fragment_types"
                 ].split(";"),

--- a/gui/workflows/PeptideCentric.v1.json
+++ b/gui/workflows/PeptideCentric.v1.json
@@ -239,11 +239,23 @@
                     ]
                 },
                 {
-                    "id": "checkpoint_folder_path",
-                    "name": "PeptDeep Model",
+                    "id": "peptdeep_model_path",
+                    "name": "PeptDeep Model Path",
                     "value": "",
                     "description": "Select a custom PeptDeep model for library prediction. This can be a DDA or DIA trained model. Please make sure that you use the same instrument type and NCE for prediction as the model was trained on.",
                     "type": "singleFolderSelection"
+                },
+                {
+                    "id": "peptdeep_model_type",
+                    "name": "PeptDeep Model Type",
+                    "value": "generic",
+                    "description": "Select a custom pretrained PeptDeep model for library prediction. Possible values are 'generic', 'phospho' and 'digly'.",
+                    "type": "dropdown",
+                    "options": [
+                        "generic",
+                        "phospho",
+                        "digly"
+                    ]
                 }
 
             ]


### PR DESCRIPTION
Allows selection of alternative pretrained models shipped with peptdeep