### PR TITLE
Make fragment calibration configurable

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -119,6 +119,12 @@ calibration:
   # TODO: remove this parameter
   norm_rt_mode: 'linear'
 
+  # the maximum number of fragments with correlation scores exceeding correlation_threshold to use for calibrating fragment mz (i.e. ms2)
+  max_fragments: 5000
+
+  # the correlation threshold for fragments used to calibrate fragment mz (i.e. ms2)
+  min_correlation: 0.7
+
 search_initial:
   # Number of peak groups identified in the convolution score to classify with target decoy comeptition
   initial_num_candidates: 1

--- a/alphadia/workflow/peptidecentric.py
+++ b/alphadia/workflow/peptidecentric.py
@@ -549,7 +549,10 @@ class PeptideCentricWorkflow(base.WorkflowBase):
             by="correlation", ascending=False
         )
         # Determine the number of fragments to keep
-        min_fragments, max_fragments = 500, self.config["calibration"]["max_fragments"]
+        min_fragments, max_fragments = (
+            500,
+            self.config["calibration"]["max_fragments"],
+        )  # TODO remove min_fragments as it seems to have no effect
         min_correlation = self.config["calibration"]["min_correlation"]
 
         high_corr_count = (fragments_df_filtered["correlation"] > min_correlation).sum()

--- a/alphadia/workflow/peptidecentric.py
+++ b/alphadia/workflow/peptidecentric.py
@@ -549,8 +549,8 @@ class PeptideCentricWorkflow(base.WorkflowBase):
             by="correlation", ascending=False
         )
         # Determine the number of fragments to keep
-        min_fragments, max_fragments = 500, 5000
-        min_correlation = 0.7
+        min_fragments, max_fragments = 500, self.config["calibration"]["max_fragments"]
+        min_correlation = self.config["calibration"]["min_correlation"]
 
         high_corr_count = (fragments_df_filtered["correlation"] > min_correlation).sum()
         stop_rank = min(max(high_corr_count, min_fragments), max_fragments)


### PR DESCRIPTION
Currently, the version of automatic calibration that has performed the best is from before we fixed the bug that artificially reduced the number of fragments we picked relative to our intention; it always picked the 500 best fragments. It is possible that calibrating on this higher-quality set meaningfully improves performance and this can be tested by making this parameter configurable. 

NB: I have not made the min_fragments configurable because I don't think that the min_fragments code actually has any effect on the way the code currently runs (if there are fewer fragments than min_fragments, calibration still proceeds with the lower number). I may therefore remove it soon.