### PR TITLE
fix error with config

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -260,7 +260,7 @@ optimization:
       automatic_update_factor: 1.1
       favour_narrower_parameter: False
       maximal_decrease: 0.8
-      minimum_proportion_of_maximum: 0.95
+      minimum_proportion_of_maximum: 0.9
   ms1_error:
       targeted_update_percentile_range: 0.95
       targeted_update_factor: 1.0
@@ -268,7 +268,7 @@ optimization:
       automatic_update_factor: 1.1
       favour_narrower_parameter: False
       maximal_decrease: 0.8
-      minimum_proportion_of_maximum: 0.95
+      minimum_proportion_of_maximum: 0.9
   mobility_error:
       targeted_update_percentile_range: 0.95
       targeted_update_factor: 1.0
@@ -276,7 +276,7 @@ optimization:
       automatic_update_factor: 1.1
       favour_narrower_parameter: False
       maximal_decrease: 0.8
-      minimum_proportion_of_maximum: 0.95
+      minimum_proportion_of_maximum: 0.9
   rt_error:
       targeted_update_percentile_range: 0.95
       targeted_update_factor: 1.0
@@ -284,7 +284,7 @@ optimization:
       automatic_update_factor: 1.1
       favour_narrower_parameter: True
       maximal_decrease: 0.8
-      minimum_proportion_of_maximum: 0.95
+      minimum_proportion_of_maximum: 0.9
 
 # configuration for the optimization manager
 # initial parameters, will be optimized

--- a/alphadia/workflow/optimization.py
+++ b/alphadia/workflow/optimization.py
@@ -255,8 +255,7 @@ class AutomaticOptimizer(BaseOptimizer):
 
             parameter_history = self.history_df["parameter"]
             parameter_not_substantially_changed = (
-                parameter_history.iloc[-1] / parameter_history.iloc[-2]
-                > self.minimum_proportion_of_maximum
+                parameter_history.iloc[-1] / parameter_history.iloc[-2] > 0.95
             )
 
             return min_steps_reached and (
@@ -298,7 +297,8 @@ class AutomaticOptimizer(BaseOptimizer):
         if self.favour_narrower_parameter:  # This setting can be useful for optimizing parameters for which many parameter values have similar feature values.
             rows_within_thresh_of_max = self.history_df.loc[
                 self.history_df[self.feature_name]
-                > self.history_df[self.feature_name].max() * 0.9
+                > self.history_df[self.feature_name].max()
+                * self.minimum_proportion_of_maximum
             ]
             index_of_optimum = rows_within_thresh_of_max["parameter"].idxmin()
             return index_of_optimum
@@ -483,12 +483,6 @@ class AutomaticRTOptimizer(AutomaticOptimizer):
         self.estimator_group_name = "precursor"
         self.estimator_name = "rt"
         self.feature_name = "precursor_proportion_detected"
-        self.maximal_decrease = workflow.config["optimization"]["rt_error"][
-            "maximal_decrease"
-        ]
-        self.minimum_proportion_of_maximum = workflow.config["optimization"][
-            "rt_error"
-        ]["minimum_proportion_of_maximum"]
         super().__init__(initial_parameter, workflow, reporter)
 
     def _get_feature_value(


### PR DESCRIPTION
The current code uses the minimum_proportion_of_maximum field from the config in the wrong place. The behaviour of the code with default arguments should be identical after this fix. 