### PR TITLE
Use batch index at optimum

### DIFF
--- a/alphadia/workflow/optimization.py
+++ b/alphadia/workflow/optimization.py
@@ -314,7 +314,7 @@ class AutomaticOptimizer(BaseOptimizer):
             score cutoff,
             FWHM_RT,
             and FWHM_mobility
-        at the optimal parameter. Also updates the optlock with the smallest batch index.
+        at the optimal parameter. Also updates the optlock with the batch index at the optimum.
 
         """
         index_of_optimum = self._find_index_of_optimum()
@@ -345,9 +345,7 @@ class AutomaticOptimizer(BaseOptimizer):
         )
 
         batch_index_at_optimum = self.history_df["batch_idx"].loc[index_of_optimum]
-        self.workflow.optlock.batch_idx = batch_index_at_optimum  # Typically (although not necessarily) the optimal parameter is compatible with the smallest batch index is used.
-        # If optimization has proceeded far beyond the optimal value, then it is possible that the most recent batch index will be bigger.
-        # If the optimal parameter needs a larger batch size to reach the target, the batch index will just increase in the next step so no harm is done.
+        self.workflow.optlock.batch_idx = batch_index_at_optimum
 
     @abstractmethod
     def _get_feature_value(

--- a/alphadia/workflow/optimization.py
+++ b/alphadia/workflow/optimization.py
@@ -345,6 +345,8 @@ class AutomaticOptimizer(BaseOptimizer):
         )
 
         batch_index_at_optimum = self.history_df["batch_idx"].loc[index_of_optimum]
+        # Take the batch index of the optimum, at the cost of potentially getting the batch library twice if this is the same as the current batch index.
+        # The time impact of this is negligible and the benefits can be significant.
         self.workflow.optlock.batch_idx = batch_index_at_optimum
 
     @abstractmethod
@@ -768,8 +770,8 @@ class OptimizationLock:
 
         Parameters
         ----------
-        eg_idxes: np.ndarray
-            The elution group indexes to use for the next round of optimization.
+        eg_idxes: None | np.ndarray
+            The elution group indexes to use for the next round of optimization. If None, the eg_idxes for the current self.start_idx and self.stop_idx are used.
         """
         if eg_idxes is None:
             eg_idxes = self.elution_group_order[self.start_idx : self.stop_idx]

--- a/alphadia/workflow/optimization.py
+++ b/alphadia/workflow/optimization.py
@@ -344,9 +344,8 @@ class AutomaticOptimizer(BaseOptimizer):
             {"fwhm_mobility": fwhm_mobility_at_optimum}
         )
 
-        self.workflow.optlock.batch_idx = self.history_df[
-            "batch_idx"
-        ].min()  # Typically (although not necessarily) the optimal parameter is compatible with the smallest batch index is used.
+        batch_index_at_optimum = self.history_df["batch_idx"].loc[index_of_optimum]
+        self.workflow.optlock.batch_idx = batch_index_at_optimum  # Typically (although not necessarily) the optimal parameter is compatible with the smallest batch index is used.
         # If optimization has proceeded far beyond the optimal value, then it is possible that the most recent batch index will be bigger.
         # If the optimal parameter needs a larger batch size to reach the target, the batch index will just increase in the next step so no harm is done.
 

--- a/alphadia/workflow/peptidecentric.py
+++ b/alphadia/workflow/peptidecentric.py
@@ -418,6 +418,9 @@ class PeptideCentricWorkflow(base.WorkflowBase):
                         verbosity="progress",
                     )
 
+                    self.optlock.set_batch_dfs()
+                    self.optlock.update_with_calibration(self.calibration_manager)
+
                     for optimizer in optimizers:
                         optimizer.plot()
 

--- a/tests/unit_tests/test_workflow.py
+++ b/tests/unit_tests/test_workflow.py
@@ -450,6 +450,7 @@ def create_workflow_instance():
 
     class MockOptlock:
         total_elution_groups = 2000
+        batch_idx = 1
 
     workflow.optlock = MockOptlock()
 


### PR DESCRIPTION
At present, if the optimization proceeds beyond the optimum, it may cause an increase in the batch index. The next round will then start from the higher batch instead of the batch index of the optimum. This code changes it to take the batch index of the optimum, at the cost of potentially getting the batch library twice if these are the same. (But the time impact of this is negligible and the benefits can be significant.)