### PR TITLE
Additional convergence criterion

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -113,6 +113,9 @@ calibration:
   # the minimum number of steps that a given optimizer must take before it can be said to have converged
   min_steps: 2
 
+  # the maximum number of times an automatic optimizer can be skipped before it is considered to have converged
+  max_skips: 2
+
   # TODO: remove this parameter
   final_full_calibration: False
 

--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -114,7 +114,7 @@ calibration:
   min_steps: 2
 
   # the maximum number of times an automatic optimizer can be skipped before it is considered to have converged
-  max_skips: 2
+  max_skips: 1
 
   # TODO: remove this parameter
   final_full_calibration: False

--- a/alphadia/workflow/optimization.py
+++ b/alphadia/workflow/optimization.py
@@ -267,12 +267,15 @@ class AutomaticOptimizer(BaseOptimizer):
             True if the optimization has already been performed the minimum number of times and the maximum number of skips has been reached, False otherwise.
 
         """
-        return (
+        min_steps_reached = (
             self.num_prev_optimizations
-            > self.workflow.config["calibration"]["min_steps"]
-            and self.num_consecutive_skips
+            >= self.workflow.config["calibration"]["min_steps"]
+        )
+        max_skips_reached = (
+            self.num_consecutive_skips
             > self.workflow.config["calibration"]["max_skips"]
         )
+        return min_steps_reached and max_skips_reached
 
     @property
     def _just_converged(self):

--- a/alphadia/workflow/optimization.py
+++ b/alphadia/workflow/optimization.py
@@ -60,6 +60,11 @@ class BaseOptimizer(ABC):
         pass
 
     @abstractmethod
+    def skip(self):
+        """This method is used to record skipping of optimization. It can be overwritten with an empty function if skipping of optimization does not need to be recorded"""
+        pass
+
+    @abstractmethod
     def plot(self):
         """This method plots relevant information about optimization of the search parameter. This can be overwritten with an empty function if there is nothing to plot."""
 
@@ -88,7 +93,7 @@ class AutomaticOptimizer(BaseOptimizer):
         self.workflow.optimization_manager.fit({self.parameter_name: initial_parameter})
         self.has_converged = False
         self.num_prev_optimizations = 0
-        self._num_consecutive_skips = 0
+        self.num_consecutive_skips = 0
         self.update_factor = workflow.config["optimization"][self.parameter_name][
             "automatic_update_factor"
         ]
@@ -154,10 +159,10 @@ class AutomaticOptimizer(BaseOptimizer):
 
     def skip(self):
         """Increments the internal counter for the number of consecutive skips and checks if the optimization should be stopped."""
-        self._num_consecutive_skips += 1
+        self.num_consecutive_skips += 1
         if (
             self.num_consecutive_skips
-            > self.workflow.config["optimization"]["max_skips"]
+            >= self.workflow.config["calibration"]["max_skips"]
         ):
             self.has_converged = True
             self._update_workflow()
@@ -523,6 +528,10 @@ class TargetedOptimizer(BaseOptimizer):
 
     def plot(self):
         """See base class. There is nothing of interest to plot here."""
+        pass
+
+    def skip(self):
+        """See base class. There is nothing to record when skipping optimization here."""
         pass
 
 

--- a/alphadia/workflow/optimization.py
+++ b/alphadia/workflow/optimization.py
@@ -160,10 +160,7 @@ class AutomaticOptimizer(BaseOptimizer):
     def skip(self):
         """Increments the internal counter for the number of consecutive skips and checks if the optimization should be stopped."""
         self.num_consecutive_skips += 1
-        if (
-            self.num_consecutive_skips
-            >= self.workflow.config["calibration"]["max_skips"]
-        ):
+        if self._unnecessary_to_continue:
             self.has_converged = True
             self._update_workflow()
             self.reporter.log_string(

--- a/alphadia/workflow/peptidecentric.py
+++ b/alphadia/workflow/peptidecentric.py
@@ -555,7 +555,7 @@ class PeptideCentricWorkflow(base.WorkflowBase):
 
         for optimizer in optimizers:
             self.reporter.log_string(
-                f"=== Optimization of {optimizer.parameter_name} has been performed {optimizer.num_prev_optimizations} times; minimum number is {self.config['calibration']['min_steps']} ===",
+                f"=== Optimization of {optimizer.parameter_name} has been performed {optimizer.num_prev_optimizations + 1} time(s); minimum number is {self.config['calibration']['min_steps']} ===",
                 verbosity="progress",
             )
             optimizer.step(precursor_df_filtered, fragments_df_filtered)
@@ -582,7 +582,7 @@ class PeptideCentricWorkflow(base.WorkflowBase):
 
         for optimizer in optimizers:
             self.reporter.log_string(
-                f"=== Optimization of {optimizer.parameter_name} has been skipped {optimizer.num_consecutive_skips} time(s); maximum number is {self.config['calibration']['max_skips']} ===",
+                f"=== Optimization of {optimizer.parameter_name} has been skipped {optimizer.num_consecutive_skips + 1} time(s); maximum number is {self.config['calibration']['max_skips']} ===",
                 verbosity="progress",
             )
             optimizer.skip()

--- a/alphadia/workflow/peptidecentric.py
+++ b/alphadia/workflow/peptidecentric.py
@@ -419,9 +419,7 @@ class PeptideCentricWorkflow(base.WorkflowBase):
                         verbosity="progress",
                     )
 
-                    self.optlock.has_target_num_precursors = True
-                    self.optlock.set_batch_dfs()
-                    self.optlock.update_with_calibration(self.calibration_manager)
+                    self.optlock.reset_after_convergence(self.calibration_manager)
 
                     for optimizer in optimizers:
                         optimizer.plot()
@@ -554,10 +552,6 @@ class PeptideCentricWorkflow(base.WorkflowBase):
         )
 
         for optimizer in optimizers:
-            self.reporter.log_string(
-                f"=== Optimization of {optimizer.parameter_name} has been performed {optimizer.num_prev_optimizations + 1} time(s); minimum number is {self.config['calibration']['min_steps']} ===",
-                verbosity="progress",
-            )
             optimizer.step(precursor_df_filtered, fragments_df_filtered)
 
         self.reporter.log_string(
@@ -581,10 +575,6 @@ class PeptideCentricWorkflow(base.WorkflowBase):
         )
 
         for optimizer in optimizers:
-            self.reporter.log_string(
-                f"=== Optimization of {optimizer.parameter_name} has been skipped {optimizer.num_consecutive_skips + 1} time(s); maximum number is {self.config['calibration']['max_skips']} ===",
-                verbosity="progress",
-            )
             optimizer.skip()
 
     def filter_dfs(self, precursor_df, fragments_df):

--- a/tests/unit_tests/test_workflow.py
+++ b/tests/unit_tests/test_workflow.py
@@ -1020,11 +1020,15 @@ def test_optimizer_skipping():
 
     assert len(rt_optimizer.history_df) == 1
 
-    rt_optimizer.skip()
+    rt_optimizer.step(calibration_test_df1, calibration_test_df2)
+
+    assert rt_optimizer.has_converged is False
 
     rt_optimizer.skip()
 
-    assert len(rt_optimizer.history_df) == 1
+    rt_optimizer.skip()
+
+    assert len(rt_optimizer.history_df) == 2
     assert rt_optimizer.has_converged is True
 
     rt_optimizer = optimization.TargetedRTOptimizer(
@@ -1045,3 +1049,6 @@ def test_optimizer_skipping():
     rt_optimizer.step(calibration_test_df1, calibration_test_df2)
 
     assert rt_optimizer.has_converged is True
+
+
+test_optimizer_skipping()


### PR DESCRIPTION
At present, optimizers need to have reached the target number of precursors before they can converge. This poses a problem if the optimizer tries a value so narrow that it is difficult to identify the target number. However, such values are not likely to optimize the feature value (indeed, if the feature value is well chosen they shouldn't, as we should not pick parameter values that reduce precursor counts so much). This PR introduces a new set of methods which record when optimization has been skipped and considers optimization to have converged if the optimizer is skipped too many times (as defined by max_skips in the calibration field of the config). The max_skips field has a default value of 1 and is unlikely to be worth changing as long as we use an exponential batch plan, since skipping an optimizer more than once implies that performance in precursors identifications is at least roughly twice as bad as before. 