### PR TITLE
add gradient_length_m to output

### DIFF
--- a/alphadia/outputtransform.py
+++ b/alphadia/outputtransform.py
@@ -982,6 +982,8 @@ def _build_run_stat_df(
             base_dict["rt_error"] = np.nan
             base_dict["mobility_error"] = np.nan
 
+        base_dict["gradient_length_m"] = channel_df["gradient_length"].max() / 60
+
         out_df.append(base_dict)
 
     return pd.DataFrame(out_df)

--- a/alphadia/planning.py
+++ b/alphadia/planning.py
@@ -312,6 +312,7 @@ class Plan:
 
         workflow_folder_list = []
 
+        run_info = {}  # alternative
         for raw_name, dia_path, speclib in self.get_run_data():
             workflow = None
             try:
@@ -356,6 +357,11 @@ class Plan:
                 psm_df.to_parquet(psm_location, index=False)
                 frag_df.to_parquet(frag_location, index=False)
 
+                # alternative
+                run_info[raw_name] = {
+                    "gradient_length": workflow.dia_data.rt_values.max()
+                }
+
             except CustomError as e:
                 _log_exception_event(e, raw_name, workflow)
                 continue
@@ -376,7 +382,11 @@ class Plan:
                 os.path.join(self.output_folder, "speclib.hdf"), load_mod_seq=True
             )
 
-            output = outputtransform.SearchPlanOutput(self.config, self.output_folder)
+            output = outputtransform.SearchPlanOutput(
+                self.config,
+                self.output_folder,
+                # run_info # alternative
+            )
             output.build(workflow_folder_list, base_spec_lib)
         except Exception as e:
             _log_exception_event(e)

--- a/alphadia/workflow/peptidecentric.py
+++ b/alphadia/workflow/peptidecentric.py
@@ -864,6 +864,8 @@ class PeptideCentricWorkflow(base.WorkflowBase):
             fragments_df["candidate_idx"].isin(precursor_df["candidate_idx"])
         ]
 
+        precursor_df["gradient_length"] = self.dia_data.rt_values.max()
+
         self.log_precursor_df(precursor_df)
 
         return precursor_df, fragments_df


### PR DESCRIPTION
Adds gradient length in minutes to the `stats.tsv`

![image](https://github.com/user-attachments/assets/9a19efa1-e31e-442a-8710-3b8b336ecf2c)

@GeorgWa To me this feels a bit like a hack, as I add this information to every entry in the psm table, although it's a property of the whole run. Happy to take suggestions.

update: added an alternative implementation sketch (marked with `# alternative`, changes to `SearchPlanOutput` not done but should be obvious) .. if we will have more output data on the "run" level, this might be more sustainable