### PR TITLE
Fix ms2 transferlearning ms2 bug

### DIFF
--- a/alphadia/transferlearning/train.py
+++ b/alphadia/transferlearning/train.py
@@ -5,6 +5,7 @@ import pandas as pd
 import torch
 from alphabase.peptide.fragment import remove_unused_fragments
 from alphabase.peptide.mobility import ccs_to_mobility_for_df, mobility_to_ccs_for_df
+from alphabase.peptide.precursor import refine_precursor_df
 from peptdeep.model.charge import ChargeModelForModAASeq
 from peptdeep.model.model_interface import CallbackHandler, LR_SchedulerInterface
 from peptdeep.pretrained_models import ModelManager
@@ -564,13 +565,14 @@ class FinetuneManager(ModelManager):
         test_intensity_df = test_intensity_df[0]
 
         # Prepare order for peptdeep prediction
-
+        val_psm_df = refine_precursor_df(val_psm_df)
         reordered_val_psm_df = self._reset_frag_idx(val_psm_df)
         reordered_val_intensity_df = self._order_intensities(
             reordered_precursor_df=reordered_val_psm_df,
             unordered_precursor_df=val_psm_df,
             unordered_frag_df=val_intensity_df,
         )
+        test_psm_df = refine_precursor_df(test_psm_df)
         reordered_test_psm_df = self._reset_frag_idx(test_psm_df)
         reordered_test_intensity_df = self._order_intensities(
             reordered_precursor_df=reordered_test_psm_df,


### PR DESCRIPTION
A fix for #406 

This might be a good place to explain what was going on:
- From my experiences, in peptdeep when using the prediction functionality directly from the model class (instead of using predict_all in the model manager), it expects the precursors to be sorted by nAA. If they aren’t sorted, you end up with an all-zero fragments dataframe. That’s why I added the df_refinement step in this PR to handle this issue.

- When the precursors are sorted by nAA, PeptDeep drops the old fragment indices and reinitializes them (in-place) based on the refined precursors. This caused problems when trying to compare predictions with a ground truth. This part of the issue was already handled but I wanted to explain why we are doing multiple preprocessing steps before prediction, and this commit specifically fixes the nAA sorting-related problem. 

This should address both issues and ensure things work as expected.