### PR TITLE
fix the nans in accumulated transferlib bug

### DIFF
--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -34,6 +34,11 @@ jobs:
     - name: Conda info
       shell: bash -l {0}
       run: conda info
+    - name: Install mono
+      shell: bash -l {0}
+      run: |
+        conda install mono
+
     - name: Perform pip installation with all stable dependencies
       shell: bash -l {0}
       run: |

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -36,7 +36,7 @@ jobs:
       shell: bash -l {0}
       run: conda info
     - name: Install mono
-      if: ${{ contains(inputs.os, 'windows') == 'false' }}
+      if: ${{ !contains(inputs.os, 'windows') }}
       shell: bash -l {0}
       run: |
         conda install mono
@@ -44,9 +44,9 @@ jobs:
       shell: bash -l {0}
       run: |
         cd misc
-        . ./${{ inputs.install-script }} alphadia ${{ inputs.python-version }} ${{ contains(inputs.os, 'windows') == 'false' }}
+        . ./${{ inputs.install-script }} alphadia ${{ inputs.python-version }} ${{ !contains(inputs.os, 'windows') }}
     - name: Run tests
       shell: bash -l {0}
       run: |
         cd tests
-        . ./${{ inputs.test-script }} alphadia ${{ inputs.python-version }} ${{ contains(inputs.os, 'windows') == 'false' }}
+        . ./${{ inputs.test-script }} alphadia ${{ inputs.python-version }} ${{ !contains(inputs.os, 'windows') }}

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -1,5 +1,5 @@
 # reusable workflow to run tests on different installation types and OS
-name: run-tests
+name: Run unit tests on ${{ inputs.os }}
 
 on:
   workflow_call:
@@ -17,7 +17,8 @@ on:
         required: true
         type: string
 jobs:
-  run-unit-tests-stable-ubuntu:
+  run-unit-tests:
+    name: Unit tests [${{ inputs.os }}]
     runs-on: ${{ inputs.os }}
     steps:
     - uses: actions/checkout@v4
@@ -35,7 +36,7 @@ jobs:
       shell: bash -l {0}
       run: conda info
     - name: Install mono
-      if: ${{ runner.os != 'windows-latest' }}
+      if: ${{ inputs.os != 'windows-latest' }}
       shell: bash -l {0}
       run: |
         conda install mono
@@ -43,9 +44,9 @@ jobs:
       shell: bash -l {0}
       run: |
         cd misc
-        . ./${{ inputs.install-script }} alphadia ${{ inputs.python-version }} ${{ runner.os != 'windows-latest' }}
+        . ./${{ inputs.install-script }} alphadia ${{ inputs.python-version }} ${{ inputs.os != 'windows-latest' }}
     - name: Run tests
       shell: bash -l {0}
       run: |
         cd tests
-        . ./${{ inputs.test-script }} alphadia ${{ inputs.python-version }} ${{ runner.os != 'windows-latest' }}
+        . ./${{ inputs.test-script }} alphadia ${{ inputs.python-version }} ${{ inputs.os != 'windows-latest' }}

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -36,7 +36,7 @@ jobs:
       shell: bash -l {0}
       run: conda info
     - name: Install mono
-      if: ${{ inputs.os != 'windows-latest' }}
+      if: ${{ contains(inputs.os, 'windows') == 'false' }}
       shell: bash -l {0}
       run: |
         conda install mono
@@ -44,9 +44,9 @@ jobs:
       shell: bash -l {0}
       run: |
         cd misc
-        . ./${{ inputs.install-script }} alphadia ${{ inputs.python-version }} ${{ inputs.os != 'windows-latest' }}
+        . ./${{ inputs.install-script }} alphadia ${{ inputs.python-version }} ${{ contains(inputs.os, 'windows') == 'false' }}
     - name: Run tests
       shell: bash -l {0}
       run: |
         cd tests
-        . ./${{ inputs.test-script }} alphadia ${{ inputs.python-version }} ${{ inputs.os != 'windows-latest' }}
+        . ./${{ inputs.test-script }} alphadia ${{ inputs.python-version }} ${{ contains(inputs.os, 'windows') == 'false' }}

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -1,5 +1,5 @@
 # reusable workflow to run tests on different installation types and OS
-name: Run unit tests on ${{ inputs.os }}
+name: Run unit tests
 
 on:
   workflow_call:

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -35,17 +35,17 @@ jobs:
       shell: bash -l {0}
       run: conda info
     - name: Install mono
+      if: ${{ runner.os != 'windows-latest' }}
       shell: bash -l {0}
       run: |
         conda install mono
-
     - name: Perform pip installation with all stable dependencies
       shell: bash -l {0}
       run: |
         cd misc
-        . ./${{ inputs.install-script }} alphadia ${{ inputs.python-version }}
+        . ./${{ inputs.install-script }} alphadia ${{ inputs.python-version }} ${{ runner.os != 'windows-latest' }}
     - name: Run tests
       shell: bash -l {0}
       run: |
         cd tests
-        . ./${{ inputs.test-script }} alphadia ${{ inputs.python-version }}
+        . ./${{ inputs.test-script }} alphadia ${{ inputs.python-version }} ${{ runner.os != 'windows-latest' }}

--- a/.github/workflows/branch-checks.yaml
+++ b/.github/workflows/branch-checks.yaml
@@ -15,8 +15,9 @@ jobs:
 
   # For feature branches, we don't test the full matrix (os x [stable, loose]) in order to save time & resources.
   run-tests-stable:
-    name: Test stable pip installation on ubuntu-latest
+    name: Test 'stable' on ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12"]

--- a/.github/workflows/pip_installation.yml
+++ b/.github/workflows/pip_installation.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   run-unit-tests-stable:
-    name: Test stable pip installation on 3 OS
+    name: Test 'stable' on ${{ matrix.os }}
     strategy:
       matrix:
         os:  [ubuntu-latest, macos-13, windows-latest]
@@ -34,7 +34,7 @@ jobs:
       test-script: ./run_unit_tests.sh
 
   run-unit-tests-loose:
-    name: Test loose pip installation on 3 OS
+    name: Test 'loose' on ${{ matrix.os }}
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-13, windows-latest ]

--- a/alphadia/outputaccumulator.py
+++ b/alphadia/outputaccumulator.py
@@ -585,8 +585,8 @@ def ms2_quality_control(
         # use the precursor for MS2 learning if the median correlation is above the cutoff
         use_for_ms2[i] = median_correlation > precursor_correlation_cutoff
 
-        # Fix: Use loc to modify the original DataFrame instead of the view
-        spec_lib_base.fragment_intensity_df.loc[start_idx:stop_idx] = (
+        # Fix: Use iloc to modify the original DataFrame instead of the view
+        spec_lib_base.fragment_intensity_df.iloc[start_idx:stop_idx] = (
             fragment_intensity_view.values
             * (
                 fragment_correlation_view

--- a/misc/pip_install.sh
+++ b/misc/pip_install.sh
@@ -4,7 +4,7 @@ INSTALL_TYPE=$1 # stable, loose, etc..
 ENV_NAME=${2:-alphadia}
 PYTHON_VERSION=${3:-3.11}
 
-conda create -n $ENV_NAME python=$PYTHON_VERSION -y
+conda create -n $ENV_NAME python=$PYTHON_VERSION mono -y
 
 if [ "$INSTALL_TYPE" = "loose" ]; then
   INSTALL_STRING=""

--- a/misc/pip_install.sh
+++ b/misc/pip_install.sh
@@ -3,8 +3,13 @@ set -e -u
 INSTALL_TYPE=$1 # stable, loose, etc..
 ENV_NAME=${2:-alphadia}
 PYTHON_VERSION=${3:-3.11}
+INSTALL_MONO=${4:-false}
 
-conda create -n $ENV_NAME python=$PYTHON_VERSION mono -y
+if [ "$INSTALL_MONO" = "true" ]; then
+  conda create -n $ENV_NAME python=$PYTHON_VERSION mono -y
+else
+  conda create -n $ENV_NAME python=$PYTHON_VERSION -y
+fi
 
 if [ "$INSTALL_TYPE" = "loose" ]; then
   INSTALL_STRING=""


### PR DESCRIPTION
Changing from loc to iloc to fix a bug where the first row of fragments for all precursors (except the first) contained only NaNs. This issue occurred because, when using loc with a slice, both endpoints are included by default (see: [Pandas documentation on advanced indexing](https://pandas.pydata.org/docs/user_guide/advanced.html#advanced-endpoints-are-inclusive)).

In contrast, by definition of frag_start and frag_stop indices specifies that frag_stop is exclusive, which aligns with the behavior of iloc.