### PR TITLE
Add option to write fragment level quant

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -237,6 +237,7 @@ fdr:
 search_output:
   peptide_level_lfq: false
   precursor_level_lfq: false
+  fragment_quant_matrix: false
   min_k_fragments: 12
   min_correlation: 0.9
   num_samples_quadratic: 50

--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -237,7 +237,7 @@ fdr:
 search_output:
   peptide_level_lfq: false
   precursor_level_lfq: false
-  fragment_quant_matrix: false #advanced feature to write out quantitative matrix with fragment ion intensities e.g. for AlphaQuant
+  save_fragment_quant_matrix: false #advanced feature to write out quantitative matrix with fragment ion intensities e.g. for AlphaQuant
   min_k_fragments: 12
   min_correlation: 0.9
   num_samples_quadratic: 50

--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -237,7 +237,7 @@ fdr:
 search_output:
   peptide_level_lfq: false
   precursor_level_lfq: false
-  fragment_quant_matrix: false
+  fragment_quant_matrix: false #advanced feature to write out quantitative matrix with fragment ion intensities e.g. for AlphaQuant
   min_k_fragments: 12
   min_correlation: 0.9
   num_samples_quadratic: 50

--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -245,6 +245,7 @@ search_output:
   normalize_lfq: True
   # can be either "parquet" or "tsv"
   file_format: "tsv"
+  file_format_advanced: "parquet"
 
 # Configuration for the optimization of search parameters. These parameters should not normally be adjusted and are for the use of experienced users only.
 optimization:

--- a/alphadia/outputtransform.py
+++ b/alphadia/outputtransform.py
@@ -799,7 +799,7 @@ class SearchPlanOutput:
                 self.config["search_output"]["precursor_level_lfq"],
                 "mod_seq_charge_hash",
                 "precursor",
-                self.config["search_output"]["fragment_quant_matrix"],
+                self.config["search_output"]["save_fragment_quant_matrix"],
             ),
             LFQOutputConfig(
                 self.config["search_output"]["peptide_level_lfq"],

--- a/alphadia/outputtransform.py
+++ b/alphadia/outputtransform.py
@@ -786,7 +786,7 @@ class SearchPlanOutput:
 
         intensity_df, quality_df = qb.accumulate_frag_df_from_folders(folder_list)
 
-        quantlevel_configs = [ #quantgroup configs are: quantlevel, level_name, should_process, save_fragments
+        quantlevel_configs = [ #the configs specified here are: quantlevel, level_name, should_process, save_fragments
             (
                 "mod_seq_hash",
                 "peptide",

--- a/alphadia/outputtransform.py
+++ b/alphadia/outputtransform.py
@@ -3,6 +3,7 @@ import logging
 import os
 from collections import defaultdict
 from collections.abc import Iterator
+from dataclasses import dataclass
 
 import directlfq.config as lfqconfig
 import directlfq.normalization as lfqnorm
@@ -786,37 +787,40 @@ class SearchPlanOutput:
 
         intensity_df, quality_df = qb.accumulate_frag_df_from_folders(folder_list)
 
-        quantlevel_configs = [  # the configs specified here are: quantlevel, level_name, should_process, save_fragments
-            (
+        @dataclass
+        class LFQOutputConfig:
+            should_process: bool
+            quant_level: str
+            level_name: str
+            save_fragments: bool = False
+
+        quantlevel_configs = [
+            LFQOutputConfig(
+                self.config["search_output"]["precursor_level_lfq"],
                 "mod_seq_charge_hash",
                 "precursor",
-                self.config["search_output"]["precursor_level_lfq"],
-                self.config["search_output"][
-                    "fragment_quant_matrix"
-                ],  # if we write out the fragment quantities, then with precursor-level filtering
+                self.config["search_output"]["fragment_quant_matrix"],
             ),
-            (
+            LFQOutputConfig(
+                self.config["search_output"]["peptide_level_lfq"],
                 "mod_seq_hash",
                 "peptide",
-                self.config["search_output"]["peptide_level_lfq"],
-                False,
             ),
-            ("pg", "pg", True, False),  # Always process protein group level
+            LFQOutputConfig(
+                True,  # always process protein group level
+                "pg",
+                "pg",
+            ),
         ]
 
         lfq_results = {}
 
-        for (
-            quantlevel,
-            level_name,
-            should_process,
-            save_fragments,
-        ) in quantlevel_configs:
-            if not should_process:
+        for quantlevel_config in quantlevel_configs:
+            if not quantlevel_config.should_process:
                 continue
 
             logger.progress(
-                f"Performing label free quantification on the {level_name} level"
+                f"Performing label free quantification on the {quantlevel_config.level_name} level"
             )
 
             group_intensity_df, _ = qb.filter_frag_df(
@@ -824,14 +828,14 @@ class SearchPlanOutput:
                 quality_df,
                 top_n=self.config["search_output"]["min_k_fragments"],
                 min_correlation=self.config["search_output"]["min_correlation"],
-                group_column=quantlevel,
+                group_column=quantlevel_config.quant_level,
             )
 
             if len(group_intensity_df) == 0:
                 logger.warning(
-                    f"No fragments found for {level_name}, skipping label-free quantification"
+                    f"No fragments found for {quantlevel_config.level_name}, skipping label-free quantification"
                 )
-                lfq_results[level_name] = pd.DataFrame()
+                lfq_results[quantlevel_config.level_name] = pd.DataFrame()
                 continue
 
             lfq_df = qb.lfq(
@@ -843,26 +847,29 @@ class SearchPlanOutput:
                     "num_samples_quadratic"
                 ],
                 normalize=self.config["search_output"]["normalize_lfq"],
-                group_column=quantlevel,
+                group_column=quantlevel_config.quant_level,
             )
 
-            lfq_results[level_name] = lfq_df
+            lfq_results[quantlevel_config.level_name] = lfq_df
 
             if save:
-                logger.info(f"Writing {level_name} output to disk")
+                logger.info(f"Writing {quantlevel_config.level_name} output to disk")
                 write_df(
                     lfq_df,
-                    os.path.join(self.output_folder, f"{level_name}.matrix"),
+                    os.path.join(
+                        self.output_folder, f"{quantlevel_config.level_name}.matrix"
+                    ),
                     file_format=self.config["search_output"]["file_format"],
                 )
-                if save_fragments:
+                if quantlevel_config.save_fragments:
                     logger.info(
-                        f"Writing fragment quantity matrix to disk, filtered on {level_name}"
+                        f"Writing fragment quantity matrix to disk, filtered on {quantlevel_config.level_name}"
                     )
                     write_df(
                         group_intensity_df,
                         os.path.join(
-                            self.output_folder, f"fragment_{level_name}filtered.matrix"
+                            self.output_folder,
+                            f"fragment_{quantlevel_config.level_name}filtered.matrix",
                         ),
                         file_format=self.config["search_output"]["file_format"],
                     )

--- a/alphadia/outputtransform.py
+++ b/alphadia/outputtransform.py
@@ -871,7 +871,9 @@ class SearchPlanOutput:
                             self.output_folder,
                             f"fragment_{quantlevel_config.level_name}filtered.matrix",
                         ),
-                        file_format=self.config["search_output"]["file_format"],
+                        file_format=self.config["search_output"][
+                            "file_format_advanced"
+                        ],
                     )
 
         # Use protein group (pg) results for merging with psm_df

--- a/alphadia/outputtransform.py
+++ b/alphadia/outputtransform.py
@@ -862,7 +862,7 @@ class SearchPlanOutput:
                     write_df(
                         group_intensity_df,
                         os.path.join(
-                            self.output_folder, f"fragment_{level_name}filt.matrix"
+                            self.output_folder, f"fragment_{level_name}filtered.matrix"
                         ),
                         file_format=self.config["search_output"]["file_format"],
                     )

--- a/alphadia/outputtransform.py
+++ b/alphadia/outputtransform.py
@@ -854,7 +854,7 @@ class SearchPlanOutput:
                 if save_fragments:
                     logger.info(f"Writing fragment quantity matrix to disk, filtered on {level_name}")
                     write_df(
-                        lfq_df,
+                        group_intensity_df,
                         os.path.join(self.output_folder, f"fragment_{level_name}filt.matrix"),
                         file_format=self.config["search_output"]["file_format"],
                     )

--- a/alphadia/outputtransform.py
+++ b/alphadia/outputtransform.py
@@ -786,28 +786,32 @@ class SearchPlanOutput:
 
         intensity_df, quality_df = qb.accumulate_frag_df_from_folders(folder_list)
 
-        quantlevel_configs = [ #the configs specified here are: quantlevel, level_name, should_process, save_fragments
-        (
+        quantlevel_configs = [  # the configs specified here are: quantlevel, level_name, should_process, save_fragments
+            (
                 "mod_seq_charge_hash",
                 "precursor",
                 self.config["search_output"]["precursor_level_lfq"],
-                self.config["search_output"]["fragment_quant_matrix"] #if we write out the fragment quantities, then with precursor-level filtering
+                self.config["search_output"][
+                    "fragment_quant_matrix"
+                ],  # if we write out the fragment quantities, then with precursor-level filtering
             ),
             (
                 "mod_seq_hash",
                 "peptide",
                 self.config["search_output"]["peptide_level_lfq"],
-                False
+                False,
             ),
-            ("pg", 
-             "pg", 
-             True, 
-             False),  # Always process protein group level
+            ("pg", "pg", True, False),  # Always process protein group level
         ]
 
         lfq_results = {}
 
-        for quantlevel, level_name, should_process, save_fragments in quantlevel_configs:
+        for (
+            quantlevel,
+            level_name,
+            should_process,
+            save_fragments,
+        ) in quantlevel_configs:
             if not should_process:
                 continue
 
@@ -852,10 +856,14 @@ class SearchPlanOutput:
                     file_format=self.config["search_output"]["file_format"],
                 )
                 if save_fragments:
-                    logger.info(f"Writing fragment quantity matrix to disk, filtered on {level_name}")
+                    logger.info(
+                        f"Writing fragment quantity matrix to disk, filtered on {level_name}"
+                    )
                     write_df(
                         group_intensity_df,
-                        os.path.join(self.output_folder, f"fragment_{level_name}filt.matrix"),
+                        os.path.join(
+                            self.output_folder, f"fragment_{level_name}filt.matrix"
+                        ),
                         file_format=self.config["search_output"]["file_format"],
                     )
 

--- a/alphadia/outputtransform.py
+++ b/alphadia/outputtransform.py
@@ -787,17 +787,17 @@ class SearchPlanOutput:
         intensity_df, quality_df = qb.accumulate_frag_df_from_folders(folder_list)
 
         quantlevel_configs = [ #the configs specified here are: quantlevel, level_name, should_process, save_fragments
+        (
+                "mod_seq_charge_hash",
+                "precursor",
+                self.config["search_output"]["precursor_level_lfq"],
+                self.config["search_output"]["fragment_quant_matrix"] #if we write out the fragment quantities, then with precursor-level filtering
+            ),
             (
                 "mod_seq_hash",
                 "peptide",
                 self.config["search_output"]["peptide_level_lfq"],
                 False
-            ),
-            (
-                "mod_seq_charge_hash",
-                "precursor",
-                self.config["search_output"]["precursor_level_lfq"],
-                self.config["search_output"]["fragment_quant_matrix"] #if we write out the fragment quantities, then with precursor-level filtering
             ),
             ("pg", 
              "pg", 

--- a/gui/workflows/PeptideCentric.v1.json
+++ b/gui/workflows/PeptideCentric.v1.json
@@ -542,6 +542,13 @@
                     "value": false,
                     "description": "Perform label free quantification on precursor level and report as precursor matrix.",
                     "type": "boolean"
+                },
+                {
+                    "id": "save_fragment_quant_matrix",
+                    "name": "Save Fragment Quant Matrix",
+                    "value": false,
+                    "description": "Save the fragment quantity matrix to disk.",
+                    "type": "boolean"
                 }
             ]
         },

--- a/tests/e2e_tests/e2e_test_cases.yaml
+++ b/tests/e2e_tests/e2e_test_cases.yaml
@@ -85,7 +85,7 @@ test_cases:
       search_output:
         peptide_level_lfq: true
         precursor_level_lfq: true
-        fragment_quant_matrix: true
+        save_fragment_quant_matrix: true
     library_path:
       - source_url: https://datashare.biochem.mpg.de/s/e4jqILnxHPujBBP/download?files=MSFragger_library_60SPD_2.tsv
     raw_paths:
@@ -121,7 +121,7 @@ test_cases:
       search_output:
         peptide_level_lfq: true
         precursor_level_lfq: true
-        fragment_quant_matrix: false
+        save_fragment_quant_matrix: false
     fasta_paths:
       - source_url: https://datashare.biochem.mpg.de/s/WTu3rFZHNeb3uG2/download?files=2024_01_12_human.fasta
     raw_paths:
@@ -158,7 +158,7 @@ test_cases:
       search_output:
         peptide_level_lfq: true
         precursor_level_lfq: true
-        fragment_quant_matrix: false
+        save_fragment_quant_matrix: false
     fasta_paths:
       - source_url: https://datashare.biochem.mpg.de/s/WTu3rFZHNeb3uG2/download?files=2024_01_12_human.fasta
     raw_paths:
@@ -194,7 +194,7 @@ test_cases:
 #      search_output:
 #        peptide_level_lfq: true
 #        precursor_level_lfq: true
-#        fragment_quant_matrix: false
+#        save_fragment_quant_matrix: false
 #    library_path:
 #      - source_url: https://datashare.biochem.mpg.de/s/Q9D8N2mq8vlzQ1f  #speclib.mbr.hdf
 #    raw_paths:

--- a/tests/e2e_tests/e2e_test_cases.yaml
+++ b/tests/e2e_tests/e2e_test_cases.yaml
@@ -121,7 +121,6 @@ test_cases:
       search_output:
         peptide_level_lfq: true
         precursor_level_lfq: true
-        save_fragment_quant_matrix: false
     fasta_paths:
       - source_url: https://datashare.biochem.mpg.de/s/WTu3rFZHNeb3uG2/download?files=2024_01_12_human.fasta
     raw_paths:
@@ -158,7 +157,6 @@ test_cases:
       search_output:
         peptide_level_lfq: true
         precursor_level_lfq: true
-        save_fragment_quant_matrix: false
     fasta_paths:
       - source_url: https://datashare.biochem.mpg.de/s/WTu3rFZHNeb3uG2/download?files=2024_01_12_human.fasta
     raw_paths:

--- a/tests/e2e_tests/e2e_test_cases.yaml
+++ b/tests/e2e_tests/e2e_test_cases.yaml
@@ -121,7 +121,7 @@ test_cases:
       search_output:
         peptide_level_lfq: true
         precursor_level_lfq: true
-        fragment_quant_matrix: true
+        fragment_quant_matrix: false
     fasta_paths:
       - source_url: https://datashare.biochem.mpg.de/s/WTu3rFZHNeb3uG2/download?files=2024_01_12_human.fasta
     raw_paths:
@@ -158,7 +158,7 @@ test_cases:
       search_output:
         peptide_level_lfq: true
         precursor_level_lfq: true
-        fragment_quant_matrix: true
+        fragment_quant_matrix: false
     fasta_paths:
       - source_url: https://datashare.biochem.mpg.de/s/WTu3rFZHNeb3uG2/download?files=2024_01_12_human.fasta
     raw_paths:
@@ -194,7 +194,7 @@ test_cases:
 #      search_output:
 #        peptide_level_lfq: true
 #        precursor_level_lfq: true
-#        fragment_quant_matrix: true
+#        fragment_quant_matrix: false
 #    library_path:
 #      - source_url: https://datashare.biochem.mpg.de/s/Q9D8N2mq8vlzQ1f  #speclib.mbr.hdf
 #    raw_paths:

--- a/tests/e2e_tests/e2e_test_cases.yaml
+++ b/tests/e2e_tests/e2e_test_cases.yaml
@@ -85,6 +85,7 @@ test_cases:
       search_output:
         peptide_level_lfq: true
         precursor_level_lfq: true
+        fragment_quant_matrix: true
     library_path:
       - source_url: https://datashare.biochem.mpg.de/s/e4jqILnxHPujBBP/download?files=MSFragger_library_60SPD_2.tsv
     raw_paths:
@@ -120,6 +121,7 @@ test_cases:
       search_output:
         peptide_level_lfq: true
         precursor_level_lfq: true
+        fragment_quant_matrix: true
     fasta_paths:
       - source_url: https://datashare.biochem.mpg.de/s/WTu3rFZHNeb3uG2/download?files=2024_01_12_human.fasta
     raw_paths:
@@ -156,6 +158,7 @@ test_cases:
       search_output:
         peptide_level_lfq: true
         precursor_level_lfq: true
+        fragment_quant_matrix: true
     fasta_paths:
       - source_url: https://datashare.biochem.mpg.de/s/WTu3rFZHNeb3uG2/download?files=2024_01_12_human.fasta
     raw_paths:
@@ -191,6 +194,7 @@ test_cases:
 #      search_output:
 #        peptide_level_lfq: true
 #        precursor_level_lfq: true
+#        fragment_quant_matrix: true
 #    library_path:
 #      - source_url: https://datashare.biochem.mpg.de/s/Q9D8N2mq8vlzQ1f  #speclib.mbr.hdf
 #    raw_paths:

--- a/tests/unit_tests/test_outputaccumulator.py
+++ b/tests/unit_tests/test_outputaccumulator.py
@@ -50,7 +50,7 @@ def prepare_input_data():
             "normalize_lfq": True,
             "peptide_level_lfq": False,
             "precursor_level_lfq": False,
-            "fragment_quant_matrix": False,
+            "save_fragment_quant_matrix": False,
         },
         "transfer_library": {
             "enabled": True,

--- a/tests/unit_tests/test_outputaccumulator.py
+++ b/tests/unit_tests/test_outputaccumulator.py
@@ -50,7 +50,7 @@ def prepare_input_data():
             "normalize_lfq": True,
             "peptide_level_lfq": False,
             "precursor_level_lfq": False,
-            "fragment_quant_matrix": False
+            "fragment_quant_matrix": False,
         },
         "transfer_library": {
             "enabled": True,

--- a/tests/unit_tests/test_outputaccumulator.py
+++ b/tests/unit_tests/test_outputaccumulator.py
@@ -50,6 +50,7 @@ def prepare_input_data():
             "normalize_lfq": True,
             "peptide_level_lfq": False,
             "precursor_level_lfq": False,
+            "fragment_quant_matrix": False
         },
         "transfer_library": {
             "enabled": True,

--- a/tests/unit_tests/test_outputtransform.py
+++ b/tests/unit_tests/test_outputtransform.py
@@ -33,7 +33,7 @@ def test_output_transform():
             "normalize_lfq": True,
             "peptide_level_lfq": False,
             "precursor_level_lfq": False,
-            "fragment_quant_matrix": False,
+            "save_fragment_quant_matrix": False,
             "file_format": "parquet",
         },
         "multiplexing": {

--- a/tests/unit_tests/test_outputtransform.py
+++ b/tests/unit_tests/test_outputtransform.py
@@ -33,6 +33,7 @@ def test_output_transform():
             "normalize_lfq": True,
             "peptide_level_lfq": False,
             "precursor_level_lfq": False,
+            "fragment_quant_matrix": False,
             "file_format": "parquet",
         },
         "multiplexing": {


### PR DESCRIPTION
This PR adds the option to write to disk a matrix with fragment-level quantities which can be used for detailed inspection of the data or downstream quantification algorithms.

Changes:
- Extended `SearchPlanOutput.build_lfq_tables()` to support fragment-level table export. When enabled, the feature exports the precursor-level `group_intensity_df` containing all fragments that pass the precursor level correlation filters
- Added boolean config option  in `config_dict["search_output"]["fragment_quant_matrix"]` (default: false)
- Updated default config.yaml to include the new option