### PR TITLE
Adjust config and gui for max_iter parameter

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -234,6 +234,7 @@ fdr:
   channel_wise_fdr: false
   inference_strategy: "heuristic"
   enable_two_step_classifier: false
+  two_step_classifier_max_iterations: 5
   enable_nn_hyperparameter_tuning: false
 
 search_output:

--- a/alphadia/fdrx/models/two_step_classifier.py
+++ b/alphadia/fdrx/models/two_step_classifier.py
@@ -38,7 +38,7 @@ class TwoStepClassifier:
         max_iterations : int
             Maximum number of refinement iterations during training.
         train_on_top_n : int
-            Use candidates up to this rank for training.
+            Use candidates up to this rank for training. During inference, all ranks are used.
 
         """
         self.first_classifier = first_classifier

--- a/gui/workflows/PeptideCentric.v1.json
+++ b/gui/workflows/PeptideCentric.v1.json
@@ -411,6 +411,13 @@
                     "type": "boolean"
                 },
                 {
+                    "id": "two_step_classifier_max_iterations",
+                    "name": "Two Step Classifier Max Iterations",
+                    "value": 5,
+                    "description": "If two step classifier is enabled, this sets the maximum number of iterations for training the classifier.",
+                    "type": "integer"
+                },
+                {
                     "id": "enable_nn_hyperparameter_tuning",
                     "name": "Hyperparameter Tuning (Experimental)",
                     "value": false,

--- a/gui/workflows/PeptideCentric.v1.json
+++ b/gui/workflows/PeptideCentric.v1.json
@@ -412,7 +412,7 @@
                 },
                 {
                     "id": "two_step_classifier_max_iterations",
-                    "name": "Two Step Classifier Max Iterations",
+                    "name": "Two Step Classifier Max Iterations (Experimental)",
                     "value": 5,
                     "description": "If two step classifier is enabled, this sets the maximum number of iterations for training the classifier.",
                     "type": "integer"


### PR DESCRIPTION
Add the parameter `two_step_classifier_max_iterations` to config and GUI. This parameter specifies the number of iterations performed by the two classifiers within the `TwoStepClassifier.fit_predict()` method.