### PR TITLE
keep old log files

### DIFF
--- a/alphadia/workflow/reporting.py
+++ b/alphadia/workflow/reporting.py
@@ -167,7 +167,7 @@ def _move_old_logs(log_file_path: str) -> str | None:
     n = -1
     while new_path.exists():
         n += 1
-        new_path = old_path.parent / f"{old_path.stem}.{n}{old_path.suffix}"
+        new_path = old_path.parent / f"{old_path.stem}.{n}.bkp{old_path.suffix}"
 
     if n != -1:
         Path(log_file_path).rename(new_path)

--- a/tests/unit_tests/test_reporting.py
+++ b/tests/unit_tests/test_reporting.py
@@ -163,8 +163,8 @@ def test_move_old_logs_increments_log_file_name_and_moves(mock_exists, mock_rena
     log_file_path = "log.txt"
     # when
     result = _move_old_logs(log_file_path)
-    mock_rename.assert_called_once_with(Path("log.1.txt"))
-    assert result == "log.1.txt"
+    mock_rename.assert_called_once_with(Path("log.1.bkp.txt"))
+    assert result == "log.1.bkp.txt"
 
 
 @patch("alphadia.workflow.reporting.Path.rename")


### PR DESCRIPTION
do not overwrite but move old logs files .. 
(design decision: current log file name is always `log.txt`)