### PR TITLE
fix tests by adapting to changes in pytorch 2.6

### DIFF
--- a/alphadia/workflow/manager.py
+++ b/alphadia/workflow/manager.py
@@ -820,7 +820,9 @@ class FDRManager(BaseManager):
 
                     if classifier_hash not in self.classifier_store:
                         classifier = deepcopy(self.classifier_base)
-                        classifier.from_state_dict(torch.load(os.path.join(path, file)))
+                        classifier.from_state_dict(
+                            torch.load(os.path.join(path, file)), weights_only=False
+                        )
                         self.classifier_store[classifier_hash].append(classifier)
 
     def get_classifier(self, available_columns: list, version: int = -1):

--- a/alphadia/workflow/manager.py
+++ b/alphadia/workflow/manager.py
@@ -821,7 +821,7 @@ class FDRManager(BaseManager):
                     if classifier_hash not in self.classifier_store:
                         classifier = deepcopy(self.classifier_base)
                         classifier.from_state_dict(
-                            torch.load(os.path.join(path, file)), weights_only=False
+                            torch.load(os.path.join(path, file), weights_only=False)
                         )
                         self.classifier_store[classifier_hash].append(classifier)
 

--- a/tests/unit_tests/test_fdr.py
+++ b/tests/unit_tests/test_fdr.py
@@ -280,7 +280,9 @@ def test_feed_forward_save():
 
     new_classifier = fdrx.BinaryClassifierLegacy()
     new_classifier.from_state_dict(
-        torch.load(os.path.join(tempfolder, "test_feed_forward_save.pth"))
+        torch.load(
+            os.path.join(tempfolder, "test_feed_forward_save.pth"), weights_only=False
+        )
     )
 
     y_pred = new_classifier.predict(x)  # noqa: F841  # TODO fix this test


### PR DESCRIPTION
In [PyTorch 2.6](https://pytorch.org/blog/pytorch2-6/), the default value of `weights_only` in `torch.load(path, weights_only=True)` was changed to `True`, which caused our tests to fail. Their intention is that this is more secure, because not an entire model object is loaded by default, but instead only the weights. 
As a quick fix, I changed our use-cases to `weights_only=False`. 
