### PR TITLE
Remove experimental two-step-classifier parameters

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -240,10 +240,8 @@ fdr:
   channel_wise_fdr: false
   inference_strategy: "heuristic"
   # (Experimental)
-  # uses a two-step classifier consisting of a logistic regression and a neural network, with a default maximum of 5 iterations per fitting call. The logistic regression is activated only when a minimum number of precursors (default 5,000) has been detected.
+  # uses a two-step classifier consisting of a logistic regression and a neural network. The logistic regression is activated only when a minimum number of precursors (default 200) has been detected.
   enable_two_step_classifier: false
-  two_step_classifier_max_iterations: 5
-  two_step_classifier_min_precursors_for_update: 5000
   # (Experimental)
   # Optimizes the batch size and learning rate of the neural network
   enable_nn_hyperparameter_tuning: false

--- a/alphadia/fdrx/models/two_step_classifier.py
+++ b/alphadia/fdrx/models/two_step_classifier.py
@@ -21,8 +21,8 @@ class TwoStepClassifier:
         second_classifier: Classifier,
         first_fdr_cutoff: float = 0.6,
         second_fdr_cutoff: float = 0.01,
-        min_precursors_for_update: int = 5000,
-        max_iterations: int = 5,
+        min_precursors_for_update: int = 200,
+        max_iterations: int = 2,
         train_on_top_n: int = 1,
     ):
         """Initializing a two-step classifier.
@@ -37,11 +37,11 @@ class TwoStepClassifier:
             The fdr threshold for the first classifier, determining how selective the first classification step is.
         second_fdr_cutoff : float, default=0.01
             The fdr threshold for the second classifier, typically set stricter to ensure high confidence in the final classification results.
-        min_precursors_for_update : int, default=5000
+        min_precursors_for_update : int, default=200
             The minimum number of precursors required to update the first classifier.
-        max_iterations : int
+        max_iterations : int, default=2
             Maximum number of refinement iterations during training.
-        train_on_top_n : int
+        train_on_top_n : int, default=1
             Use candidates up to this rank for training. During inference, all ranks are used.
 
         """

--- a/alphadia/workflow/peptidecentric.py
+++ b/alphadia/workflow/peptidecentric.py
@@ -99,8 +99,6 @@ feature_columns = [
 
 def get_classifier_base(
     enable_two_step_classifier: bool = False,
-    two_step_classifier_max_iterations: int = 5,
-    two_step_classifier_min_precursors_for_update: int = 5000,
     enable_nn_hyperparameter_tuning: bool = False,
     fdr_cutoff: float = 0.01,
 ):
@@ -111,13 +109,6 @@ def get_classifier_base(
     enable_two_step_classifier : bool, optional
         If True, uses logistic regression + neural network.
         If False (default), uses only neural network.
-
-    two_step_classifier_max_iterations : int, optional
-        Maximum number of iterations withtin .fit_predict() of the two-step classifier.
-
-    two_step_classifier_min_precursors_for_update : int, optional
-        The minimum number of precursors required to update the logistic regression model
-        in the two-step classifier. Default is 5000.
 
     enable_nn_hyperparameter_tuning: bool, optional
         If True, uses hyperparameter tuning for the neural network.
@@ -145,8 +136,6 @@ def get_classifier_base(
             first_classifier=LogisticRegressionClassifier(),
             second_classifier=nn_classifier,
             second_fdr_cutoff=fdr_cutoff,
-            max_iterations=two_step_classifier_max_iterations,
-            min_precursors_for_update=two_step_classifier_min_precursors_for_update,
         )
     else:
         return nn_classifier
@@ -189,12 +178,6 @@ class PeptideCentricWorkflow(base.WorkflowBase):
             classifier_base=get_classifier_base(
                 enable_two_step_classifier=self.config["fdr"][
                     "enable_two_step_classifier"
-                ],
-                two_step_classifier_max_iterations=self.config["fdr"][
-                    "two_step_classifier_max_iterations"
-                ],
-                two_step_classifier_min_precursors_for_update=self.config["fdr"][
-                    "two_step_classifier_min_precursors_for_update"
                 ],
                 enable_nn_hyperparameter_tuning=self.config["fdr"][
                     "enable_nn_hyperparameter_tuning"

--- a/gui/workflows/PeptideCentric.v1.json
+++ b/gui/workflows/PeptideCentric.v1.json
@@ -427,20 +427,6 @@
                     "type": "boolean"
                 },
                 {
-                    "id": "two_step_classifier_max_iterations",
-                    "name": "Two Step Classifier Max Iterations (Experimental)",
-                    "value": 5,
-                    "description": "If two step classifier is enabled, this sets the maximum number of iterations for training the classifier.",
-                    "type": "integer"
-                },
-                {
-                    "id": "two_step_classifier_min_precursors_for_update",
-                    "name": "Two-Step Classifier Minimum Precursors for Update (Experimental)",
-                    "value": 5000,
-                    "description": "If two step classifier is enabled, this sets the minimum number of precursors required to update the first classifier (the Logistic Regression model).",
-                    "type": "integer"
-                },
-                {
                     "id": "enable_nn_hyperparameter_tuning",
                     "name": "Hyperparameter Tuning (Experimental)",
                     "value": false,


### PR DESCRIPTION
Removing the hyperparameters  in the GUI and setting defaults for `TwoStepClassifier.max_iterations` (default=2) and `.min_precursors_for_update` (default=200)