### PR TITLE
Fix config refactoring bug

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -308,7 +308,7 @@ search_output:
   normalize_lfq: True
 
   # Save fragment quant matrix for advanced users
-  save_fragment_quant_matrix: True
+  save_fragment_quant_matrix: False
 
 # Configuration for the optimization of search parameters. These parameters should not normally be adjusted and are for the use of experienced users only.
 optimization:

--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -307,6 +307,9 @@ search_output:
   # Enable normalization of label-free quantification values
   normalize_lfq: True
 
+  # Save fragment quant matrix for advanced users
+  save_fragment_quant_matrix: True
+
 # Configuration for the optimization of search parameters. These parameters should not normally be adjusted and are for the use of experienced users only.
 optimization:
   # The order in which to perform optimization. Should be a list of lists of parameter names

--- a/tests/e2e_tests/e2e_test_cases.yaml
+++ b/tests/e2e_tests/e2e_test_cases.yaml
@@ -37,6 +37,9 @@ test_cases:
   - name: multistep
     # see also transfer-dimethyl.md
     config:
+      general:
+        transfer_step_enabled: True
+        mbr_step_enabled: True
       search:
 #        target_num_candidates: # mbr: 3
         target_ms1_tolerance: 4
@@ -53,9 +56,7 @@ test_cases:
         variable_modifications: 'Oxidation@M;Acetyl@Protein_N-term'
         max_var_mod_num: 1 # mbr: 2
         missed_cleavages: 0  # mbr: 1
-      multistep_search:
-        transfer_step_enabled: True
-        mbr_step_enabled: True
+
     # dimethyl data (from tutorial)
     fasta_paths:
       - source_url: https://datashare.biochem.mpg.de/s/1GiKQSwlPf6YlMm/download?path=%2F&files=2024_01_12_human.fasta


### PR DESCRIPTION
Fixes two bugs which showed up in e2e testing:

- during config refactoring `save_fragment_quant_matrix` was lost.
- the e2e tests weren't updated after the config refactoring

Key Takeaway: run e2e on relevant PRs