### PR TITLE
Update prediction config to use enabled pattern

### DIFF
--- a/alphadia/__init__.py
+++ b/alphadia/__init__.py
@@ -1,3 +1,4 @@
 #!python
 
+
 __version__ = "1.9.3-dev6"

--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -42,7 +42,7 @@ library_loading:
 library_prediction:
   # Basic parameters
   # whether to use alphaPeptDeep to predict peptide properties
-  predict: False
+  enabled: false
   # enzyme used for in-silico digest
   enzyme: trypsin
   # fixed modifications for in-silico digest

--- a/alphadia/search_plan.py
+++ b/alphadia/search_plan.py
@@ -125,7 +125,7 @@ class SearchPlan:
                     "peptdeep_model_path": os.path.join(
                         self._transfer_step_output_dir, SearchPlanOutput.TRANSFER_MODEL
                     ),
-                    "predict": True,  # the step following the 'transfer' step needs to have this
+                    "enabled": True,  # the step following the 'transfer' step needs to have this
                 }
             }
 

--- a/alphadia/search_step.py
+++ b/alphadia/search_step.py
@@ -179,10 +179,10 @@ class SearchStep:
 
         prediction_config = self.config["library_prediction"]
 
-        if self.library_path is None and not prediction_config["predict"]:
+        if self.library_path is None and not prediction_config["enabled"]:
             logger.error("No library provided and prediction disabled.")
             return
-        elif self.library_path is None and prediction_config["predict"]:
+        elif self.library_path is None and prediction_config["enabled"]:
             logger.progress("No library provided. Building library from fasta files.")
 
             fasta_digest = libtransform.FastaDigest(
@@ -207,7 +207,7 @@ class SearchStep:
 
         thread_count = self.config["general"]["thread_count"]
 
-        if prediction_config["predict"]:
+        if prediction_config["enabled"]:
             logger.progress("Predicting library properties.")
 
             pept_deep_prediction = libtransform.PeptDeepPrediction(

--- a/gui/workflows/PeptideCentric.v1.json
+++ b/gui/workflows/PeptideCentric.v1.json
@@ -174,8 +174,8 @@
             "hidden": false,
             "parameters": [
                 {
-                    "id": "predict",
-                    "name": "Predict Library",
+                    "id": "enabled",
+                    "name": "Enable Prediction",
                     "default": false,
                     "description": "Use alphaPeptDeep to predict peptide. \n If a FASTA file is provided an in silico digest will be performed. \n If a spectral library is provided precursor properties for library precursor will be performed.",
                     "type": "boolean"

--- a/tests/e2e_tests/e2e_test_cases.yaml
+++ b/tests/e2e_tests/e2e_test_cases.yaml
@@ -48,7 +48,7 @@ test_cases:
       transfer_learning:
         epochs: 5  # this is reduced to speed the test up a little
       library_prediction:
-        predict: True
+        enabled: True
         precursor_mz:
           - 380
           - 980
@@ -99,7 +99,7 @@ test_cases:
   - name: astral
     config:
       library_prediction:
-        predict: true
+        enabled: true
         fixed_modifications: 'Carbamidomethyl@C'
         variable_modifications: 'Oxidation@M;Acetyl@Protein N-term'
         max_var_mod_num: 2
@@ -135,7 +135,7 @@ test_cases:
   - name: astral_automatic_calibration
     config:
       library_prediction:
-        predict: true
+        enabled: true
         fixed_modifications: 'Carbamidomethyl@C'
         variable_modifications: 'Oxidation@M;Acetyl@Protein N-term'
         max_var_mod_num: 2
@@ -170,7 +170,7 @@ test_cases:
 #  - name: astral_mixed_species
 #    config:
 #      library_prediction:
-#        predict: true
+#        enabled: true
 #        fixed_modifications: 'Carbamidomethyl@C'
 #        variable_modifications: 'Oxidation@M;Acetyl@Protein N-term'
 #        max_var_mod_num: 2

--- a/tests/unit_tests/test_search_plan.py
+++ b/tests/unit_tests/test_search_plan.py
@@ -133,7 +133,7 @@ def test_runs_plan_with_transfer_step(
                 "peptdeep_model_path": _convert_path(
                     "/user_provided_output_path/transfer/peptdeep.transfer"
                 ),
-                "predict": True,
+                "enabled": True,
             },
         }
         | dynamic_config,
@@ -238,7 +238,7 @@ def test_runs_plan_with_transfer_and_mbr_steps(
                 "peptdeep_model_path": str(
                     Path("/user_provided_output_path/transfer/peptdeep.transfer")
                 ),
-                "predict": True,
+                "enabled": True,
             },
         }
         | dynamic_config,

--- a/tests/unit_tests/test_search_step.py
+++ b/tests/unit_tests/test_search_step.py
@@ -20,7 +20,7 @@ def test_fasta_digest():
     tempdir = tempfile.gettempdir()
     step = search_step.SearchStep(
         tempdir,
-        config={"library_prediction": {"predict": True}},
+        config={"library_prediction": {"enabled": True}},
         cli_config={"fasta_paths": [common_contaminants]},
     )
 
@@ -33,7 +33,7 @@ def test_fasta_digest():
     # predict existing library
     step = search_step.SearchStep(
         tempdir,
-        config={"library_prediction": {"predict": True}},
+        config={"library_prediction": {"enabled": True}},
         cli_config={"library_path": speclib_path},
     )
     assert len(step.spectral_library.precursor_df) > 0
@@ -42,7 +42,7 @@ def test_fasta_digest():
     # load existing library without predict
     step = search_step.SearchStep(
         tempdir,
-        config={"library_prediction": {"predict": False}},
+        config={"library_prediction": {"enabled": False}},
         cli_config={"library_path": speclib_path},
     )
     assert len(step.spectral_library.precursor_df) > 0


### PR DESCRIPTION
So far, all but one config groups have used the following pattern for configuration:
```yaml
config_group:
   enabled: true
```
This PR introduces a breaking change and updates the config group library prediction to use the same pattern.