### PR TITLE
fix wrong config key

### DIFF
--- a/alphadia/outputtransform.py
+++ b/alphadia/outputtransform.py
@@ -880,9 +880,7 @@ class SearchPlanOutput:
                             self.output_folder,
                             f"fragment_{quantlevel_config.level_name}filtered.matrix",
                         ),
-                        file_format=self.config["search_output"][
-                            "file_format_advanced"
-                        ],
+                        file_format=self.config["search_output"]["file_format"],
                     )
 
         # Use protein group (pg) results for merging with psm_df


### PR DESCRIPTION
The config key was changed but not in the function which uses it:

```
1:32:03.521803 INFO: Writing precursor output to disk
1:32:03.521968 INFO: Saving synchropasef/output/library/precursor.matrix.tsv to disk
1:32:03.869976 INFO: Writing fragment quantity matrix to disk, filtered on precursor
1:32:03.870130 ERROR: Error: 'file_format_advanced'
Traceback (most recent call last):
  File "/home/runner/_work/alphadia/alphadia/alphadia/search_step.py", line 325, in run
    output.build(workflow_folder_list, base_spec_lib)
  File "/home/runner/_work/alphadia/alphadia/alphadia/outputtransform.py", line 377, in build
    _ = self.build_lfq_tables(folder_list, psm_df=psm_df, save=True)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/alphadia/alphadia/alphadia/outputtransform.py", line 883, in build_lfq_tables
    file_format=self.config["search_output"][
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'file_format_advanced'
1:32:03.884183 INFO: Traceback (most recent call last):
  File "/home/runner/_work/alphadia/alphadia/alphadia/cli.py", line 232, in run
    SearchPlan(output_directory, user_config, cli_params_config).run_plan()
  File "/home/runner/_work/alphadia/alphadia/alphadia/search_plan.py", line 154, in run_plan
    self.run_step(
  File "/home/runner/_work/alphadia/alphadia/alphadia/search_plan.py", line 193, in run_step
    step.run()
  File "/home/runner/_work/alphadia/alphadia/alphadia/search_step.py", line 328, in run
    raise e
  File "/home/runner/_work/alphadia/alphadia/alphadia/search_step.py", line 325, in run
    output.build(workflow_folder_list, base_spec_lib)
  File "/home/runner/_work/alphadia/alphadia/alphadia/outputtransform.py", line 377, in build
    _ = self.build_lfq_tables(folder_list, psm_df=psm_df, save=True)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/alphadia/alphadia/alphadia/outputtransform.py", line 883, in build_lfq_tables
    file_format=self.config["search_output"][
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'file_format_advanced'

1:32:03.884258 ERROR: 'file_format_advanced'

```