### PR TITLE
Simplify init library

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -172,9 +172,6 @@ calibration:
   # the maximum number of times an automatic optimizer can be skipped before it is considered to have converged
   max_skips: 1
 
-  # TODO: remove this parameter
-  norm_rt_mode: 'linear'
-
   # the maximum number of fragments with correlation scores exceeding correlation_threshold to use for calibrating fragment mz (i.e. ms2)
   max_fragments: 5000
 

--- a/alphadia/workflow/config.py
+++ b/alphadia/workflow/config.py
@@ -130,6 +130,13 @@ class Config(UserDict):
         )
 
 
+# keys that have been removed from the config but are still tolerated
+# Note: if multiple levels have been removed, multiple entries are needed, e.g. ["removed_key_level1, removed_key_level1.removed_key_level2"]
+TOLERATED_KEYS = [
+    "calibration.norm_rt_mode"  # supported until 1.10.4
+]
+
+
 def _update(
     target_config: dict,
     update_config: dict,
@@ -169,7 +176,13 @@ def _update(
     """
     for key, update_value in update_config.items():
         full_key = f"{parent_keys}.{key}" if parent_keys else key
+
         if key not in target_config:
+            if full_key in TOLERATED_KEYS:
+                logger.warning(
+                    f"Key '{full_key}' has been removed from AlphaDIA. Please update your config.yaml as this will be an error in future versions."
+                )
+                continue
             raise KeyAddedConfigError(full_key, update_value, config_name)
 
         target_value = target_config[key]

--- a/alphadia/workflow/peptidecentric/library_init.py
+++ b/alphadia/workflow/peptidecentric/library_init.py
@@ -2,22 +2,23 @@ import numpy as np
 from alphabase.spectral_library.base import SpecLibBase
 
 from alphadia.reporting.reporting import Pipeline
-from alphadia.workflow.config import Config
 
 
 def init_spectral_library(
-    config: Config,
     dia_cycle: np.ndarray,
     dia_rt_values: np.ndarray,
     reporter: Pipeline,
     spectral_library: SpecLibBase,
+    channel_filter: str | None = None,
 ) -> None:
     """Initialize the spectral library.
 
+    Normalizes the normalized retention time values form the spectral library to the observed RT values.
+    Filters the spectral library based on the observed mz values.
+    Optionally filters the spectral library to only contain precursors from selected channels (if set in config).
+
     Parameters
     ----------
-    config : Config
-        Configuration object containing search and calibration parameters.
     dia_cycle : np.ndarray
         Array of DIA cycle values, used to determine the mz limits for filtering.
     dia_rt_values : np.ndarray
@@ -26,11 +27,9 @@ def init_spectral_library(
         Reporter object for logging messages.
     spectral_library : SpecLibBase
         Spectral library object containing precursor information, will be modified in place.
-
-
-    Normalizes the normalized retention time values form the spectral library to the observed RT values.
-    Filters the spectral library based on the observed mz values.
-    Optionally filters the spectral library to only contain precursors from selected channels (if set in config).
+    channel_filter : str, optional
+        Comma-separated string of channel numbers to filter the spectral library (column "channel") by.
+        If empty, no filtering is applied.
 
     Returns
     -------
@@ -41,7 +40,7 @@ def init_spectral_library(
     """
     # normalize RT
     spectral_library.precursor_df["rt_library"] = _norm_to_rt(
-        config, dia_rt_values, spectral_library.precursor_df["rt_library"].values
+        dia_rt_values, spectral_library.precursor_df["rt_library"].values
     )
 
     # filter based on precursor observability
@@ -62,10 +61,8 @@ def init_spectral_library(
     # filter spectral library to only contain precursors from allowed channels
     spectral_library.precursor_df_unfiltered = spectral_library.precursor_df.copy()
 
-    if config["search"]["channel_filter"] != "":
-        selected_channels = [
-            int(c) for c in config["search"]["channel_filter"].split(",")
-        ]
+    if channel_filter:
+        selected_channels = [int(c) for c in channel_filter.split(",")]
 
         spectral_library.precursor_df = spectral_library.precursor_df_unfiltered[
             spectral_library.precursor_df_unfiltered["channel"].isin(selected_channels)
@@ -77,12 +74,8 @@ def init_spectral_library(
 
 
 def _norm_to_rt(
-    config: Config,
     dia_rt_values: np.ndarray,
     norm_values: np.ndarray,
-    active_gradient_start: float | None = None,
-    active_gradient_stop: float | None = None,
-    mode: str | None = None,
 ) -> np.ndarray:
     """Convert normalized retention time values to absolute retention time values.
 
@@ -94,51 +87,16 @@ def _norm_to_rt(
     norm_values : np.ndarray
         Array of normalized retention time values from the spectral library.
 
-    active_gradient_start : float, optional
-        Start of the active gradient in seconds, by default None.
-        If None, it is set to the first retention time value plus half the configured `initial_rt_tolerance`.
-
-    active_gradient_stop : float, optional
-        End of the active gradient in seconds, by default None.
-        If None, it is set to the last retention time value minus half the configured `initial_rt_tolerance`.
-
-    mode : str, optional
-        Mode of the gradient, by default None.
-        If None, the value from the config is used which should be 'linear' by default
-
     Returns
     -------
     np.ndarray
         Array of absolute retention time values corresponding to the normalized values.
     """
-    # TODO: "initial retention time tolerance in seconds if > 1, or a proportion of the total gradient length if < 1" not reflected here!
-    # TODO: would expect the signs turned around?
-    lower_rt = (
-        (dia_rt_values[0] + config["search_initial"]["initial_rt_tolerance"] / 2)
-        if active_gradient_start is None
-        else active_gradient_start
-    )
-
-    upper_rt = (
-        dia_rt_values[-1] - (config["search_initial"]["initial_rt_tolerance"] / 2)
-        if active_gradient_stop is None
-        else active_gradient_stop
-    )
 
     # make sure values are really norm values
     norm_values = np.interp(norm_values, [norm_values.min(), norm_values.max()], [0, 1])
 
-    # determine the mode based on the config or the function parameter
-    mode = (
-        config["calibration"].get("norm_rt_mode", "linear")
-        if mode is None
-        else mode.lower()
-    )
+    lower_rt = dia_rt_values[0]
+    upper_rt = dia_rt_values[-1]
 
-    if mode == "linear":
-        return np.interp(norm_values, [0, 1], [lower_rt, upper_rt])
-
-    if mode == "tic":
-        raise NotImplementedError("tic mode is not implemented yet")
-
-    raise ValueError(f"Unknown norm_rt_mode {mode}")
+    return np.interp(norm_values, [0, 1], [lower_rt, upper_rt])

--- a/alphadia/workflow/peptidecentric/library_init.py
+++ b/alphadia/workflow/peptidecentric/library_init.py
@@ -28,7 +28,7 @@ def init_spectral_library(
     spectral_library : SpecLibBase
         Spectral library object containing precursor information, will be modified in place.
     channel_filter : str, optional
-        Comma-separated string of channel numbers to filter the spectral library (column "channel") by.
+        Comma-separated string of channel numbers (integers) to filter the spectral library (column "channel") by.
         If empty, no filtering is applied.
 
     Returns

--- a/alphadia/workflow/peptidecentric/peptidecentric.py
+++ b/alphadia/workflow/peptidecentric/peptidecentric.py
@@ -120,11 +120,11 @@ class PeptideCentricWorkflow(base.WorkflowBase):
         )
 
         init_spectral_library(
-            self.config,
             self.dia_data.cycle,
             self.dia_data.rt_values,
             self.reporter,
             self.spectral_library,
+            self.config["search"]["channel_filter"],
         )
 
         self._extraction_handler = ExtractionHandler(

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,5 +1,6 @@
 import os
 from io import StringIO
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -201,6 +202,21 @@ def test_config_update_new_key_raises():
     # when
     with pytest.raises(KeyAddedConfigError):
         config_1.update([config_2], do_print=True)
+
+
+@patch("alphadia.workflow.config.TOLERATED_KEYS", ["nested_values.new_key2"])
+def test_config_update_new_key_tolerated():
+    """Test updating a config with a new key that is tolerated."""
+    config_1 = Config(yaml.safe_load(StringIO(generic_default_config)), "default")
+
+    # mock_tolerated_keys.return_value = lambda: ["new_key"]
+
+    config_2 = Config({"nested_values": {"new_key2": 0}}, "first")
+
+    # when
+    config_1.update([config_2], do_print=True)
+
+    assert config_1 == expected_generic_default_config_dict
 
 
 def test_config_update_type_mismatch_raises():

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -209,8 +209,6 @@ def test_config_update_new_key_tolerated():
     """Test updating a config with a new key that is tolerated."""
     config_1 = Config(yaml.safe_load(StringIO(generic_default_config)), "default")
 
-    # mock_tolerated_keys.return_value = lambda: ["new_key"]
-
     config_2 = Config({"nested_values": {"new_key2": 0}}, "first")
 
     # when


### PR DESCRIPTION
as discussed:
- remove using `config["search_initial"]["initial_rt_tolerance"]`: this has never been adapted to `initial_rt_tolerance` being small now by default (3e0b7424) and therefore should have no effect (according to @GeorgWa )
- unused "mode" has been removed
- add option to config to tolerate removed keys in order to prevent breaking changes