### PR TITLE
disable MBR step in default configuration

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -16,7 +16,7 @@ general:
   transfer_step_enabled: false
 
   # Enables separate MBR step
-  mbr_step_enabled: true
+  mbr_step_enabled: false
 
   # === advanced settings ===
   # whether to reuse previously calculated calibration data


### PR DESCRIPTION
Resetting to one-step search as this causes too much confusion (confused people count: 4)