### PR TITLE
reverting fd86f3f

### DIFF
--- a/alphadia/workflow/optimizers/optimization_lock.py
+++ b/alphadia/workflow/optimizers/optimization_lock.py
@@ -213,7 +213,7 @@ class OptimizationLock:
         if eg_idxes is None:
             eg_idxes = self._elution_group_order[self.start_idx : self.stop_idx]
         self.batch_library = SpecLibFlat()
-        # TODO using batch_library.precursor_df here will trigger the setter method, which will additionally call refine_precursor_df()
+        # TODO using batch_library.precursor_df (no underscore) here will trigger the setter method, which will additionally call refine_precursor_df()
         self.batch_library._precursor_df, (self.batch_library._fragment_df,) = (
             remove_unused_fragments(
                 self._library._precursor_df[

--- a/alphadia/workflow/peptidecentric/library_init.py
+++ b/alphadia/workflow/peptidecentric/library_init.py
@@ -39,37 +39,39 @@ def init_spectral_library(
             - precursor_df_unfiltered attribute is set to the original precursor dataframe.
     """
     # normalize RT
-    spectral_library.precursor_df["rt_library"] = _norm_to_rt(
-        dia_rt_values, spectral_library.precursor_df["rt_library"].values
+    spectral_library._precursor_df["rt_library"] = _norm_to_rt(
+        dia_rt_values, spectral_library._precursor_df["rt_library"].values
     )
 
     # filter based on precursor observability
     lower_mz_limit = dia_cycle[dia_cycle > 0].min()
     upper_mz_limit = dia_cycle[dia_cycle > 0].max()
 
-    n_precursor_before = np.sum(spectral_library.precursor_df["decoy"] == 0)
-    spectral_library.precursor_df = spectral_library.precursor_df[
-        (spectral_library.precursor_df["mz_library"] >= lower_mz_limit)
-        & (spectral_library.precursor_df["mz_library"] <= upper_mz_limit)
+    # TODO using spectral_library.precursor_df (no underscore) here will trigger the setter method, which will additionally call refine_precursor_df()
+
+    n_precursor_before = np.sum(spectral_library._precursor_df["decoy"] == 0)
+    spectral_library._precursor_df = spectral_library._precursor_df[
+        (spectral_library._precursor_df["mz_library"] >= lower_mz_limit)
+        & (spectral_library._precursor_df["mz_library"] <= upper_mz_limit)
     ]
-    n_precursors_after = np.sum(spectral_library.precursor_df["decoy"] == 0)
+    n_precursors_after = np.sum(spectral_library._precursor_df["decoy"] == 0)
     reporter.log_string(
         f"Initializing spectral library: {n_precursors_after:,} target precursors potentially observable ({n_precursor_before - n_precursors_after:,} removed)",
         verbosity="progress",
     )
 
     # filter spectral library to only contain precursors from allowed channels
-    spectral_library.precursor_df_unfiltered = spectral_library.precursor_df.copy()
+    spectral_library.precursor_df_unfiltered = spectral_library._precursor_df.copy()
 
     if channel_filter:
         selected_channels = [int(c) for c in channel_filter.split(",")]
 
-        spectral_library.precursor_df = spectral_library.precursor_df_unfiltered[
+        spectral_library._precursor_df = spectral_library.precursor_df_unfiltered[
             spectral_library.precursor_df_unfiltered["channel"].isin(selected_channels)
         ].copy()
 
         reporter.log_string(
-            f"Initializing spectral library: applied channel filter using only {selected_channels}, {len(spectral_library.precursor_df):,} precursors left",
+            f"Initializing spectral library: applied channel filter using only {selected_channels}, {len(spectral_library._precursor_df):,} precursors left",
         )
 
 


### PR DESCRIPTION
This fixes an issue introduced in #592, which lead to a quality degradation (few percent of ids).

Explanation:
 (https://github.com/MannLabs/alphadia/pull/592/files#diff-18bcdaed364cfa34d8a6c3b93f0d255f8192eee0b2034bbc0471015404469569R223):
it makes a difference whether on sets  `SpeclibBase.precursor_df` with or without trailing underscore, as the latter will call a setter method (https://github.com/MannLabs/alphabase/blob/main/alphabase/spectral_library/base.py#L130) which entails additional modifications (https://github.com/MannLabs/alphabase/blob/main/alphabase/peptide/precursor.py#L18):
In our case:
- some data type manipulations
- `na`-filling
- resorting by nAA
- index resetting

@GeorgWa @jalew188 any idea what could cause the troubles here?

These are the other places in alphadia where the setter is still being used:
https://github.com/MannLabs/alphadia/blob/ebd1e24cff1fb7f4bdf745b93efd95dd315dc3a4/alphadia/libtransform/fasta_digest.py#L105
https://github.com/MannLabs/alphadia/blob/ebd1e24cff1fb7f4bdf745b93efd95dd315dc3a4/alphadia/libtransform/fasta_digest.py#L117
https://github.com/MannLabs/alphadia/blob/ebd1e24cff1fb7f4bdf745b93efd95dd315dc3a4/alphadia/libtransform/multiplex.py#L58
https://github.com/MannLabs/alphadia/blob/ebd1e24cff1fb7f4bdf745b93efd95dd315dc3a4/alphadia/workflow/peptidecentric/fragment_requantification_handler.py#L212
