### PR TITLE
fix inconsistent output paths

### DIFF
--- a/alphadia/search_step.py
+++ b/alphadia/search_step.py
@@ -146,7 +146,9 @@ class SearchStep:
             config.update(config_updates, do_print=True)
 
         # Note: if not provided by CLI, output_folder is set to the value in config in cli.py
-        if (current_config_output_folder := config.get(ConfigKeys.OUTPUT_DIRECTORY)) is not None and current_config_output_folder != output_folder:
+        if (
+            current_config_output_folder := config.get(ConfigKeys.OUTPUT_DIRECTORY)
+        ) is not None and current_config_output_folder != output_folder:
             logger.warning(
                 f"Using output directory '{output_folder}' provided via CLI, the value specified in config ('{current_config_output_folder}') will be ignored."
             )

--- a/alphadia/search_step.py
+++ b/alphadia/search_step.py
@@ -145,8 +145,12 @@ class SearchStep:
         if config_updates:
             config.update(config_updates, do_print=True)
 
-        if config.get(ConfigKeys.OUTPUT_DIRECTORY, None) is None:
-            config[ConfigKeys.OUTPUT_DIRECTORY] = output_folder
+        # Note: if not provided by CLI, output_folder is set to the value in config in cli.py
+        if (current_config_output_folder := config.get(ConfigKeys.OUTPUT_DIRECTORY)) is not None and current_config_output_folder != output_folder:
+            logger.warning(
+                f"Using output directory '{output_folder}' provided via CLI, the value specified in config ('{current_config_output_folder}') will be ignored."
+            )
+        config[ConfigKeys.OUTPUT_DIRECTORY] = output_folder
 
         return config
 

--- a/tests/unit_tests/test_search_step.py
+++ b/tests/unit_tests/test_search_step.py
@@ -95,20 +95,22 @@ def test_updates_with_user_and_cli_and_extra_config_dicts(
 
 
 @patch("alphadia.search_step.SearchStep._load_default_config")
-def test_updates_with_cli_config_no_overwrite_output_path(
+def test_updates_with_cli_config_overwrite_output_path(
     mock_load_default_config,
 ):
-    """Test that the output directory is not overwritten if provided by config."""
-    config = Config({"key1": "value1", "output_directory": None})
+    """Test that the output directory is overwritten if provided by cli."""
+    config = Config({"key1": "value1", "output_directory": "/some_output_directory"})
     mock_load_default_config.return_value = deepcopy(config)
 
-    user_config = {"key1": "value1b", "output_directory": "/output"}
+    user_config = {"key1": "value1b", "output_directory": "/another_output_directory"}
     # when
-    result = SearchStep._init_config(user_config, None, None, "/another_output")
+    result = SearchStep._init_config(
+        user_config, None, None, "/actual_output_directory"
+    )
 
     mock_load_default_config.assert_called_once()
 
-    assert result == {"key1": "value1b", "output_directory": "/output"}
+    assert result == {"key1": "value1b", "output_directory": "/actual_output_directory"}
 
 
 @patch("alphadia.search_step.SearchStep._load_default_config")


### PR DESCRIPTION
This bug could in certain cases lead to having two different output directories.
Now the CLI always wins