### PR TITLE
Add intensity to precursor table

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -318,10 +318,6 @@ fdr:
 search_output:
   # Output file format for search results. Can be either "tsv" or "parquet"
   file_format: "tsv"
-  # Enable label-free quantification at peptide level and generate peptide matrix
-  peptide_level_lfq: false
-  # Enable label-free quantification at precursor level and generate precursor matrix
-  precursor_level_lfq: false
   # Save fragment quant matrix for advanced users
   save_fragment_quant_matrix: False
 

--- a/alphadia/outputtransform/search_plan_output.py
+++ b/alphadia/outputtransform/search_plan_output.py
@@ -38,7 +38,6 @@ class LFQOutputConfig:
     level_name: str
     intensity_column: str
     aggregation_components: list[str]
-    should_process: bool = True
     save_fragments: bool = False
 
 
@@ -528,7 +527,6 @@ class SearchPlanOutput:
                 level_name="precursor",
                 intensity_column="precursor.intensity",
                 aggregation_components=["pg", "sequence", "mods", "charge"],
-                should_process=self.config["search_output"]["precursor_level_lfq"],
                 save_fragments=self.config["search_output"][
                     "save_fragment_quant_matrix"
                 ],
@@ -538,7 +536,6 @@ class SearchPlanOutput:
                 level_name="peptide",
                 intensity_column="peptide.intensity",
                 aggregation_components=["pg", "sequence", "mods"],
-                should_process=self.config["search_output"]["peptide_level_lfq"],
                 save_fragments=self.config["search_output"][
                     "save_fragment_quant_matrix"
                 ],
@@ -548,7 +545,6 @@ class SearchPlanOutput:
                 level_name="pg",
                 intensity_column="pg.intensity",
                 aggregation_components=["pg"],
-                should_process=True,
             ),
         ]
 

--- a/gui/workflows/PeptideCentric.v1.json
+++ b/gui/workflows/PeptideCentric.v1.json
@@ -543,20 +543,6 @@
                         "tsv",
                         "parquet"
                     ]
-                },
-                {
-                    "id": "peptide_level_lfq",
-                    "name": "Peptide level LFQ",
-                    "default": false,
-                    "description": "Perform label free quantification on peptide level and report as peptide matrix.",
-                    "type": "boolean"
-                },
-                {
-                    "id": "precursor_level_lfq",
-                    "name": "Precursor level LFQ",
-                    "default": false,
-                    "description": "Perform label free quantification on precursor level and report as precursor matrix.",
-                    "type": "boolean"
                 }
             ],
             "parameters_advanced": [

--- a/tests/e2e_tests/e2e_test_cases.yaml
+++ b/tests/e2e_tests/e2e_test_cases.yaml
@@ -84,8 +84,6 @@ test_cases:
         initial_mobility_tolerance: 0.08
         initial_rt_tolerance: 240
       search_output:
-        peptide_level_lfq: true
-        precursor_level_lfq: true
         save_fragment_quant_matrix: true
     library_path:
       - source_url: https://datashare.biochem.mpg.de/public.php/dav/files/e4jqILnxHPujBBP/MSFragger_library_60SPD_2.tsv
@@ -119,9 +117,6 @@ test_cases:
         initial_ms1_tolerance: 10
         initial_ms2_tolerance: 15
         initial_rt_tolerance: 300
-      search_output:
-        peptide_level_lfq: true
-        precursor_level_lfq: true
     fasta_paths:
       - source_url: https://datashare.biochem.mpg.de/public.php/dav/files/WTu3rFZHNeb3uG2/2024_01_12_human.fasta
     raw_paths:
@@ -155,9 +150,6 @@ test_cases:
         initial_ms1_tolerance: 100
         initial_ms2_tolerance: 100
         initial_rt_tolerance: 600
-      search_output:
-        peptide_level_lfq: true
-        precursor_level_lfq: true
     fasta_paths:
       - source_url: https://datashare.biochem.mpg.de/public.php/dav/files/WTu3rFZHNeb3uG2/2024_01_12_human.fasta
     raw_paths:
@@ -191,8 +183,6 @@ test_cases:
 #        initial_ms2_tolerance: 15
 #        initial_rt_tolerance: 300
 #      search_output:
-#        peptide_level_lfq: true
-#        precursor_level_lfq: true
 #        save_fragment_quant_matrix: false
 #    library_path:
 #      - source_url: https://datashare.biochem.mpg.de/s/Q9D8N2mq8vlzQ1f  #speclib.mbr.hdf

--- a/tests/unit_tests/outputtransform/test_outputaccumulator.py
+++ b/tests/unit_tests/outputtransform/test_outputaccumulator.py
@@ -51,8 +51,6 @@ def prepare_input_data():
             "num_samples_quadratic": 50,
             "min_nonnan": 1,
             "normalize_lfq": True,
-            "peptide_level_lfq": False,
-            "precursor_level_lfq": False,
             "save_fragment_quant_matrix": False,
         },
         "transfer_library": {

--- a/tests/unit_tests/outputtransform/test_search_plan_output.py
+++ b/tests/unit_tests/outputtransform/test_search_plan_output.py
@@ -36,8 +36,6 @@ def test_output_transform():
             "num_samples_quadratic": 50,
             "min_nonnan": 1,
             "normalize_lfq": True,
-            "peptide_level_lfq": False,
-            "precursor_level_lfq": False,
             "save_fragment_quant_matrix": False,
             "file_format": "parquet",
         },
@@ -207,8 +205,9 @@ def test_merge_quant_levels_to_psm_handles_empty_lfq_results():
 
     result = search_plan_output._merge_quant_levels_to_psm(psm_df, lfq_results, configs)
 
-    assert len(result) == 1
-    assert "precursor.intensity" not in result.columns
+    expected = pd.DataFrame({"mod_seq_charge_hash": ["A1"], "run": ["run1"]})
+
+    pd.testing.assert_frame_equal(result, expected)
 
 
 def test_merge_quant_levels_to_psm_merges_all_levels():
@@ -244,6 +243,16 @@ def test_merge_quant_levels_to_psm_merges_all_levels():
 
     result = search_plan_output._merge_quant_levels_to_psm(psm_df, lfq_results, configs)
 
-    assert list(result["precursor.intensity"].values) == [100.0]
-    assert list(result["peptide.intensity"].values) == [400.0]
-    assert list(result["pg.intensity"].values) == [700.0]
+    expected = pd.DataFrame(
+        {
+            "mod_seq_charge_hash": ["A1"],
+            "mod_seq_hash": ["A"],
+            "pg": ["PG1"],
+            "run": ["run1"],
+            "precursor.intensity": [100.0],
+            "peptide.intensity": [400.0],
+            "pg.intensity": [700.0],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
For a long time, precursor and peptide information was missing from the precursor output table.
This breaking change adds in the LFQ intensities for pprecursor, peptide and proteins.

It's a breaking chnage because we start introducing semantic column names like:
`pg => pg.intensity, precursor.intensity, peptide.intensity`
@mschwoer 
It's also a breaking change because we drop `peptide_level_lfq` and `precursor_level_lfq` as it will always be performed.