### PR TITLE
Use all cores in distrobuted search

### DIFF
--- a/misc/distributed_search/inner.sh
+++ b/misc/distributed_search/inner.sh
@@ -15,11 +15,13 @@ cd $chunk_directory || exit
 # config file fixed as config.yaml
 config_filename="config.yaml"
 
+N_THREADS=$N_CPUS
+
 # run with or without custom quant_dir
 if [ -z "${quant_dir}" ]; then
-    alphadia --config ${config_filename}
+    alphadia --config ${config_filename} --config-dict "{\"general\": {\"thread_count\": $N_THREADS}}"
 else
-    alphadia --config ${config_filename} --quant-dir ${quant_dir}
+    alphadia --config ${config_filename} --config-dict "{\"general\": {\"thread_count\": $N_THREADS}}" --quant-dir ${quant_dir}
 fi
 
 echo "AlphaDIA completed successfully"

--- a/misc/distributed_search/outer.sh
+++ b/misc/distributed_search/outer.sh
@@ -119,7 +119,7 @@ if [[ "$predict_library" -eq 1 ]]; then
 	--cpus-per-task=${cpus} \
 	--mem=${mem} \
 	--output="${home_directory}/logs/%j-%x-speclib-slurm.out" \
-	--export=ALL --wrap="alphadia --config=speclib_config.yaml"
+	--export=ALL,N_CPUS=$cpus --wrap="alphadia --config=speclib_config.yaml"
 
 	# navigate back to home directory
 	cd "${home_directory}"
@@ -156,7 +156,7 @@ if [[ "$first_search" -eq 1 ]]; then
 	--ntasks-per-node=${ntasks_per_node} \
 	--cpus-per-task=${cpus} \
 	--mem=${mem} \
-	--export=ALL,target_directory=${first_search_directory},quant_dir=${mbr_progress_directory} ./inner.sh
+	--export=ALL,N_CPUS=$cpus,target_directory=${first_search_directory},quant_dir=${mbr_progress_directory} ./inner.sh
 else
 	echo "Skipping first search"
 fi
@@ -187,7 +187,7 @@ if [[ "$mbr_library" -eq 1 ]]; then
 	--ntasks-per-node=${ntasks_per_node} \
 	--cpus-per-task=${cpus} \
 	--mem=${mem} \
-	--export=ALL,target_directory=${mbr_library_directory} ./inner.sh
+	--export=ALL,N_CPUS=$cpus,target_directory=${mbr_library_directory} ./inner.sh
 else
 	echo "Skipping MBR library building"
 fi
@@ -217,7 +217,7 @@ if [[ "$second_search" -eq 1 ]]; then
 	--ntasks-per-node=${ntasks_per_node} \
 	--cpus-per-task=${cpus} \
 	--mem=${mem} \
-	--export=ALL,target_directory=${second_search_directory},quant_dir=${lfq_progress_directory} ./inner.sh
+	--export=ALL,N_CPUS=$cpus,target_directory=${second_search_directory},quant_dir=${lfq_progress_directory} ./inner.sh
 else
 	echo "Skipping second search"
 fi
@@ -248,7 +248,7 @@ if [[ "$lfq" -eq 1 ]]; then
 	--ntasks-per-node=${ntasks_per_node} \
 	--cpus-per-task=${cpus} \
 	--mem=${mem} \
-	--export=ALL,target_directory=${lfq_directory} ./inner.sh
+	--export=ALL,N_CPUS=$cpus,target_directory=${lfq_directory} ./inner.sh
 else
 	echo "Skipping LFQ"
 fi

--- a/misc/distributed_search/outer.sh
+++ b/misc/distributed_search/outer.sh
@@ -11,8 +11,8 @@
 #SBATCH --output=./logs/%j-%x-slurm.out
 
 # Set behavior when errors are encountered
-# # TODO: unresolved issues with failing on error due to library generation steps expecting AlphaDIA to fail since there are no rawfiles.
-set -u -x
+# add -x for debugging
+set -u -e
 
 # Default search parameters
 nnodes=1


### PR DESCRIPTION
- pass n cores to alphadia
- set `-e` flag as AlphaDIA now gracefully exits on 0 files