### PR TITLE
Add configurable option to do precursor/peptide level lfq

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -322,6 +322,8 @@ search_output:
   peptide_level_lfq: false
   # Enable label-free quantification at precursor level and generate precursor matrix
   precursor_level_lfq: false
+  # Save fragment quant matrix for advanced users
+  save_fragment_quant_matrix: False
 
   # === advanced settings ===
   # Minimum number of fragments required for quantification
@@ -334,9 +336,6 @@ search_output:
   min_nonnan: 3
   # Enable normalization of label-free quantification values
   normalize_lfq: True
-
-  # Save fragment quant matrix for advanced users
-  save_fragment_quant_matrix: False
 
 # Configuration for the optimization of search parameters. These parameters should not normally be adjusted and are for the use of experienced users only.
 optimization:

--- a/alphadia/outputtransform/search_plan_output.py
+++ b/alphadia/outputtransform/search_plan_output.py
@@ -522,17 +522,21 @@ class SearchPlanOutput:
 
         quantlevel_configs = [
             LFQOutputConfig(
-                should_process=True,
+                should_process=self.config["search_output"]["precursor_level_lfq"],
                 quant_level="mod_seq_charge_hash",
                 level_name="precursor",
-                save_fragments=True,
+                save_fragments=self.config["search_output"][
+                    "save_fragment_quant_matrix"
+                ],
                 aggregation_components=["pg", "sequence", "mods", "charge"],
             ),
             LFQOutputConfig(
-                should_process=True,
+                should_process=self.config["search_output"]["peptide_level_lfq"],
                 quant_level="mod_seq_hash",
                 level_name="peptide",
-                save_fragments=True,
+                save_fragments=self.config["search_output"][
+                    "save_fragment_quant_matrix"
+                ],
                 aggregation_components=["pg", "sequence", "mods"],
             ),
             LFQOutputConfig(


### PR DESCRIPTION
Add configurable option to do precursor/peptide level lfq and save fragment quant matrix

this was accidentally dropped here https://github.com/MannLabs/alphadia/pull/641/files#diff-0f853aa6e7abd0a9cd0e31e98728c9c18a4a0927e2af6d5caacbf76420242a7bR543