### PR TITLE
fix issue with frozen config when dumping numpy types

### DIFF
--- a/alphadia/workflow/config.py
+++ b/alphadia/workflow/config.py
@@ -143,6 +143,7 @@ def _convert_numpy_types(data: Any) -> Any:
     """Recursively convert numpy types to native Python types for YAML serialization.
 
     These could come from dynamically set values, e.g. calculated mass tolerances in multi-step searches.
+    Note: no need to handle tuples or sets since YAML doesn't have native tuple/set types.
 
     Parameters
     ----------
@@ -162,6 +163,10 @@ def _convert_numpy_types(data: Any) -> Any:
         return data.item()
     elif isinstance(data, np.ndarray):
         return data.tolist()
+    elif isinstance(data, list | set):
+        raise NotImplementedError(
+            "Tuples and sets are not supported in config serialization."
+        )
     else:
         return data
 

--- a/tests/unit_tests/workflow/test_config.py
+++ b/tests/unit_tests/workflow/test_config.py
@@ -321,8 +321,8 @@ def test_config_to_yaml_converts_numpy_types():
 
         config_with_numpy.to_yaml(temp_path)
 
-        with open(temp_path) as f:
-            yaml_content = f.read()
+        with open(temp_path) as f2:
+            yaml_content = f2.read()
 
         loaded_config = yaml.safe_load(yaml_content)
 


### PR DESCRIPTION
in multistep search, frozen config would looked like this
```
search:
  extraction_backend: classic
  target_ms1_tolerance: !!python/object/apply:numpy.core.multiarray.scalar
  - &id001 !!python/object/apply:numpy.dtype
    args:
    - f8
    - false
    - true
    state: !!python/tuple
    - 3
    - <
    - null
    - null
    - null
    - -1
    - -1
    - 0
  - !!binary |
    AAAAAAAAFEA=
  target_ms2_tolerance: !!python/object/apply:numpy.core.multiarray.scalar
  - *id001
  - !!binary |
    AAAAAAAAJEA=

```