### PR TITLE
explicitly set all dtypes

### DIFF
--- a/alphadia/workflow/peptidecentric/ng/ng_mapper.py
+++ b/alphadia/workflow/peptidecentric/ng/ng_mapper.py
@@ -32,12 +32,12 @@ def dia_data_to_ng(dia_data: DiaData) -> "DiaDataNG":  # noqa: F821
     ]
 
     return DiaDataNG.from_arrays(
-        delta_scan_idx,
+        delta_scan_idx.astype(np.int64),
         spectrum_df["isolation_lower_mz"].values.astype(np.float32),
         spectrum_df["isolation_upper_mz"].values.astype(np.float32),
-        spectrum_df["peak_start_idx"].values,
-        spectrum_df["peak_stop_idx"].values,
-        cycle_idx,
+        spectrum_df["peak_start_idx"].values.astype(np.int64),
+        spectrum_df["peak_stop_idx"].values.astype(np.int64),
+        cycle_idx.astype(np.int64),
         spectrum_df["rt"].values.astype(np.float32) * 60,
         peak_df["mz"].values.astype(np.float32),
         peak_df["intensity"].values.astype(np.float32),


### PR DESCRIPTION

Fixes the following issue (Windows only).

```  File "C:\Users\...\miniforge3\envs\alphadia_1.12.2_ng\Lib\site-packages\alphadia\workflow\peptidecentric\ng\ng_mapper.py", line 34, in dia_data_to_ng
    return DiaDataNG.from_arrays(
           ^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument 'spectrum_delta_scan_idx': 'ndarray' object cannot be converted to 'PyArray<T, D>'
```

Analysis by CC:

```
  The error occurred because:

  1. Platform-dependent numpy behavior: On Windows, np.arange() defaults to int32, while on Mac/Linux it typically defaults to int64
  2. Rust type requirements: The Rust code in alpha-rs/src/dia_data/mod.rs:44 expects PyReadonlyArray1<'py, i64> (int64) for several parameters
  3. Missing explicit type casts: The Python code in ng_mapper.py was not explicitly specifying dtypes when creating arrays
```

ceterum censeo .. 