### PR TITLE
[claude] Avoid Rust-DataFrame round-trips in candidate pipeline

### DIFF
--- a/alphadia/constants/default.yaml
+++ b/alphadia/constants/default.yaml
@@ -181,6 +181,9 @@ search:
   # the number of most intense fragments to use in the selection
   top_k_fragments_selection: 12
 
+  # minimum number of matched fragments at the apex cycle to keep a candidate during selection (rust backend only)
+  min_fragments_selection: 3
+
   # the number of most intense fragments to use in the scoring
   top_k_fragments_scoring: 12
 

--- a/alphadia/fdr/zscore_nn_classifier.py
+++ b/alphadia/fdr/zscore_nn_classifier.py
@@ -11,6 +11,13 @@ import numpy as np
 
 from alphadia.fdr.classifiers import BinaryClassifierLegacyNewBatching, Classifier
 
+try:
+    from alphadia_search_rs import zscore_filter_mask as _zscore_filter_mask_rs
+
+    _HAS_RUST_ZSCORE = True
+except ImportError:
+    _HAS_RUST_ZSCORE = False
+
 logger = logging.getLogger()
 
 ZSCORE_FEATURES = [
@@ -22,7 +29,6 @@ ZSCORE_FEATURES = [
 ]
 
 ZSCORE_FDR_THRESHOLD = 0.50
-MIN_MATCHED_STRICT = 3
 _MIN_STD = 1e-10
 
 
@@ -124,6 +130,39 @@ class ZScoreNNClassifier(Classifier):
         """Set the available columns (called before fit if not passed to constructor)."""
         self._available_columns = columns
 
+    def _zscore_survivors(self, x: np.ndarray, zscore_cols: list[int]) -> np.ndarray:
+        """Compute z-score filter mask using Rust if available, else numpy.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            Feature matrix of shape (n_samples, n_features).
+        zscore_cols : list[int]
+            Column indices for z-score features.
+
+        Returns
+        -------
+        np.ndarray
+            Boolean mask of shape (n_samples,). True = passes z-score filter.
+
+        """
+        p = self._zscore_params
+        if _HAS_RUST_ZSCORE:
+            return _zscore_filter_mask_rs(
+                np.ascontiguousarray(x, dtype=np.float64),
+                zscore_cols,
+                p["means"].tolist(),
+                p["stds"].tolist(),
+                p["signs"].tolist(),
+                self._threshold,
+            )
+
+        feat = np.nan_to_num(
+            x[:, zscore_cols].astype(np.float64), nan=0.0, posinf=0.0, neginf=0.0
+        )
+        scores = np.sum((feat - p["means"]) / p["stds"] * p["signs"], axis=1)
+        return scores >= self._threshold
+
     def fit(self, x: np.ndarray, y: np.ndarray) -> None:
         """Fit z-score threshold on rank 0, then train NN on survivors.
 
@@ -164,12 +203,8 @@ class ZScoreNNClassifier(Classifier):
             r0_t_scores, r0_d_scores, self._zscore_fdr_threshold
         )
 
-        # Score all candidates and filter
-        all_feat = np.nan_to_num(
-            x[:, zscore_cols].astype(np.float64), nan=0.0, posinf=0.0, neginf=0.0
-        )
-        all_scores = np.sum((all_feat - means) / stds * signs, axis=1)
-        survivors = all_scores >= self._threshold
+        # Score all candidates and filter (uses Rust if available)
+        survivors = self._zscore_survivors(x, zscore_cols)
 
         logger.info(
             f"Z-score pre-filter: {survivors.sum():,} / {len(x):,} survivors "
@@ -208,13 +243,8 @@ class ZScoreNNClassifier(Classifier):
         """
         rank_col, zscore_cols, nn_cols = self._resolve_columns()
 
-        # Z-score filter
-        feat = np.nan_to_num(
-            x[:, zscore_cols].astype(np.float64), nan=0.0, posinf=0.0, neginf=0.0
-        )
-        p = self._zscore_params
-        scores = np.sum((feat - p["means"]) / p["stds"] * p["signs"], axis=1)
-        survivors = scores >= self._threshold
+        # Z-score filter (uses Rust if available)
+        survivors = self._zscore_survivors(x, zscore_cols)
 
         # Default: all are decoys
         proba = np.zeros((len(x), 2))

--- a/alphadia/workflow/peptidecentric/extraction_handler.py
+++ b/alphadia/workflow/peptidecentric/extraction_handler.py
@@ -1,8 +1,10 @@
 from abc import ABC, abstractmethod
 
+import numpy as np
 import pandas as pd
 from alphabase.spectral_library.flat import SpecLibFlat
 from alphadia_search_rs import (
+    CandidateCollection,
     PeakGroupQuantification,
     PeakGroupScoring,
     PeakGroupSelection,
@@ -12,7 +14,6 @@ from alphadia_search_rs import (
 )
 
 from alphadia.constants.keys import CalibCols
-from alphadia.fragcomp.utils import candidate_hash
 from alphadia.raw_data import DiaData
 from alphadia.raw_data.alpharaw_wrapper import DEFAULT_VALUE_NO_MOBILITY
 from alphadia.reporting.reporting import Pipeline
@@ -27,8 +28,7 @@ from alphadia.workflow.managers.fdr_manager import FDRManager
 from alphadia.workflow.managers.optimization_manager import OptimizationManager
 from alphadia.workflow.peptidecentric.column_name_handler import ColumnNameHandler
 from alphadia.workflow.peptidecentric.ng.ng_mapper import (
-    candidates_to_ng,
-    parse_candidates,
+    candidates_to_df,
     parse_quantification,
     speclib_to_ng,
     to_features_df,
@@ -530,17 +530,37 @@ class NgExtractionHandler(ExtractionHandler):
                 fragment_mz_column=self._column_name_handler.get_fragment_mz_column(),
             )
 
-    def _select_candidates(
+    def select_candidates(
         self,
-        dia_data: "DiaDataNG",  # noqa: F821
+        dia_data: "DiaData | DiaDataNG",  # noqa: F821
         spectral_library: SpecLibFlat,
-    ) -> pd.DataFrame:
-        """Select candidates using NG backend.
+        apply_cutoff: bool = False,
+    ) -> CandidateCollection:
+        """Select candidates using NG backend, returning CandidateCollection directly.
 
-        See superclass documentation for interface details.
+        Overrides the base class to keep candidates in Rust-native format,
+        avoiding Rust→DataFrame→Rust round-trips between pipeline stages.
+
+        Parameters
+        ----------
+        dia_data : DiaData | DiaDataNG
+            DIA data to extract from.
+        spectral_library : SpecLibFlat
+            Spectral library containing precursors and fragments
+        apply_cutoff : bool
+            Whether to apply score cutoff filtering
+
+        Returns
+        -------
+        CandidateCollection
+            Rust-native candidate collection
         """
-
         self._lazy_init_speclib_ng(spectral_library)
+
+        self._reporter.log_string(
+            f"Extracting batch of {len(spectral_library.precursor_df)} precursors",
+            verbosity="progress",
+        )
 
         self._log_parameters()
 
@@ -548,8 +568,8 @@ class NgExtractionHandler(ExtractionHandler):
         selection_params.update(
             {
                 "fwhm_rt": self._optimization_manager.fwhm_rt,
-                # 'kernel_size': 20,  # 15?
                 "top_k_fragments": self._config["search"]["top_k_fragments_selection"],
+                "min_fragments": self._config["search"]["min_fragments_selection"],
                 "peak_length": self._config["search"]["quant_window"],
                 "mass_tolerance": self._optimization_manager.ms2_error,
                 "rt_tolerance": self._optimization_manager.rt_error,
@@ -561,23 +581,53 @@ class NgExtractionHandler(ExtractionHandler):
             dia_data, self._speclib_ng
         )
 
-        cands = parse_candidates(candidates, spectral_library, dia_data)
+        if apply_cutoff:
+            n_before = candidates.len()
+            candidates = candidates.filter_by_score(
+                self._optimization_manager.score_cutoff
+            )
+            self._reporter.log_string(
+                f"Removed {n_before - candidates.len()} precursors with score below cutoff "
+                f"{self._optimization_manager.score_cutoff}",
+            )
 
-        return cands
+        return candidates
+
+    def _select_candidates(
+        self,
+        dia_data: "DiaDataNG",  # noqa: F821
+        spectral_library: SpecLibFlat,
+    ) -> CandidateCollection:
+        """Select candidates using NG backend.
+
+        Note: For the NG backend, select_candidates() is overridden, so this
+        method is only called as fallback.
+        """
+        return self.select_candidates(dia_data, spectral_library, apply_cutoff=False)
 
     def score_candidates(
         self,
-        candidates_df: pd.DataFrame,
+        candidates: CandidateCollection,
         dia_data: "DiaDataNG",  # noqa: F821
         spectral_library: SpecLibFlat,
     ) -> pd.DataFrame:
         """Score candidates using NG backend.
 
-        See superclass documentation for interface details.
+        Parameters
+        ----------
+        candidates : CandidateCollection
+            Rust-native candidate collection
+        dia_data : DiaDataNG
+            DIA data to extract from.
+        spectral_library : SpecLibFlat
+            Spectral library
+
+        Returns
+        -------
+        pd.DataFrame
+            Features dataframe with scoring results
         """
         self._lazy_init_speclib_ng(spectral_library)
-
-        candidates = candidates_to_ng(candidates_df, dia_data)
 
         scoring_params = ScoringParameters()
         scoring_params.update(
@@ -597,7 +647,7 @@ class NgExtractionHandler(ExtractionHandler):
 
     def quantify_candidates(
         self,
-        candidates_df: pd.DataFrame,
+        candidates: CandidateCollection,
         precursor_fdr_df: pd.DataFrame | None,
         dia_data: "DiaDataNG",  # noqa: F821
         spectral_library: SpecLibFlat,
@@ -605,24 +655,38 @@ class NgExtractionHandler(ExtractionHandler):
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """Quantify candidates using NG backend.
 
-        See superclass documentation for interface details.
+        Parameters
+        ----------
+        candidates : CandidateCollection
+            Rust-native candidate collection (FDR-filtered)
+        precursor_fdr_df : pd.DataFrame | None
+            DataFrame with post-FDR precursor results
+        dia_data : DiaDataNG
+            DIA data to extract from.
+        spectral_library : SpecLibFlat
+            Spectral library
+        top_k_fragments : int, optional
+            Top k fragments for quantification
+
+        Returns
+        -------
+        tuple[pd.DataFrame, pd.DataFrame]
+            Precursor dataframe and fragments dataframe
         """
         self._lazy_init_speclib_ng(spectral_library)
 
-        candidates_collection = candidates_to_ng(candidates_df, dia_data)
-
-        # run quantification
         quant_params = QuantificationParameters()
         if top_k_fragments is not None:
             quant_params.update({"top_k_fragments": top_k_fragments})
 
         peak_group_quantification = PeakGroupQuantification(quant_params)
         quantified_lib = peak_group_quantification.quantify(
-            dia_data, self._speclib_ng, candidates_collection
+            dia_data, self._speclib_ng, candidates
         )
         precursor_df, fragments_df = parse_quantification(quantified_lib)
 
-        # merge in missing columns
+        # Convert to DataFrame only for the final merge (small after FDR filtering)
+        candidates_df = candidates_to_df(candidates, spectral_library, dia_data)
         precursor_df = CandidateScoring.merge_candidate_data(
             precursor_df, candidates_df
         )
@@ -670,21 +734,22 @@ class NgExtractionHandler(ExtractionHandler):
     def perform_fdr_and_filter_candidates(
         self,
         features_df: pd.DataFrame,
-        candidates_df: pd.DataFrame,
-    ) -> tuple[pd.DataFrame, pd.DataFrame]:
-        """Perform FDR on features and filter candidates accordingly.
+        candidates: CandidateCollection,
+    ) -> tuple[CandidateCollection, pd.DataFrame]:
+        """Perform FDR on features and filter CandidateCollection accordingly.
 
-        See superclass documentation for interface details.
+        Parameters
+        ----------
+        features_df : pd.DataFrame
+            DataFrame with features (scored candidates)
+        candidates : CandidateCollection
+            Rust-native candidate collection
+
+        Returns
+        -------
+        tuple[CandidateCollection, pd.DataFrame]
+            Filtered candidate collection and post-FDR precursor dataframe
         """
-
-        features_df["_candidate_idx"] = candidate_hash(
-            features_df["precursor_idx"].values, features_df["rank"].values
-        )
-        candidates_df["_candidate_idx"] = candidate_hash(
-            candidates_df["precursor_idx"].values, candidates_df["rank"].values
-        )
-
-        # apply FDR to PSMs
         precursor_fdr_df = self._fdr_manager.fit_predict(
             features_df,
             decoy_strategy="precursor",  # TODO support channel_wise, raise error for now
@@ -696,10 +761,9 @@ class NgExtractionHandler(ExtractionHandler):
             precursor_fdr_df["qval"] <= self._config["fdr"]["fdr"]
         ]
 
-        # filter2: candidates by precursors
-        candidates_filtered = candidates_df[
-            candidates_df["_candidate_idx"].isin(precursor_fdr_df["_candidate_idx"])
-        ].copy()
-        del candidates_filtered["_candidate_idx"]
+        candidates_filtered = candidates.filter_by_keys(
+            precursor_fdr_df["precursor_idx"].values.astype(np.uint64),
+            precursor_fdr_df["rank"].values.astype(np.uint64),
+        )
 
         return candidates_filtered, precursor_fdr_df

--- a/alphadia/workflow/peptidecentric/ng/ng_mapper.py
+++ b/alphadia/workflow/peptidecentric/ng/ng_mapper.py
@@ -92,36 +92,41 @@ def get_feature_names() -> list[str]:
     ]
 
 
-def parse_candidates(
+def candidates_to_df(
     candidates: CandidateCollection, spectral_library: SpecLibFlat, dia_data: DiaDataNG
 ) -> pd.DataFrame:
-    """Parse candidates from NG to classic format."""
+    """Convert CandidateCollection to a DataFrame for merge_candidate_data.
 
+    Only used at the end of the pipeline on FDR-filtered survivors (small).
+
+    Parameters
+    ----------
+    candidates : CandidateCollection
+        Rust candidate collection
+    spectral_library : SpecLibFlat
+        Spectral library for elution_group_idx lookup
+    dia_data : DiaDataNG
+        DIA data (needed for cycle_len to convert cycles to frames)
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with candidate columns needed by merge_candidate_data
+    """
     cycle_len = dia_data.cycle.shape[1]
-
     result = candidates.to_arrays()
-
-    precursor_idx = result[0]
-    rank = result[1]
-    score = result[2]
-    scan_center = result[3]
-    scan_start = result[4]
-    scan_stop = result[5]
-    frame_center = result[6]
-    frame_start = result[7]
-    frame_stop = result[8]
 
     candidates_df = pd.DataFrame(
         {
-            "precursor_idx": precursor_idx,
-            "rank": rank,
-            "score": score,
-            "scan_center": scan_center,
-            "scan_start": scan_start,
-            "scan_stop": scan_stop,
-            "frame_center": frame_center,
-            "frame_start": frame_start,
-            "frame_stop": frame_stop,
+            "precursor_idx": result[0],
+            "rank": result[1],
+            "score": result[2],
+            "scan_center": result[3],
+            "scan_start": result[4],
+            "scan_stop": result[5],
+            "frame_center": result[6],
+            "frame_start": result[7],
+            "frame_stop": result[8],
         }
     )
 
@@ -140,27 +145,6 @@ def parse_candidates(
     candidates_df["scan_center"] = 0
 
     return candidates_df
-
-
-def candidates_to_ng(
-    candidates_df: pd.DataFrame, dia_data: DiaDataNG
-) -> CandidateCollection:
-    """Convert candidates from classic to NG format."""
-
-    cycle_len = dia_data.cycle.shape[1]
-
-    candidates = CandidateCollection.from_arrays(
-        candidates_df["precursor_idx"].values.astype(np.uint64),
-        candidates_df["rank"].values.astype(np.uint64),
-        candidates_df["score"].values.astype(np.float32),
-        candidates_df["scan_center"].values.astype(np.uint64),
-        candidates_df["scan_start"].values.astype(np.uint64),
-        candidates_df["scan_stop"].values.astype(np.uint64),
-        candidates_df["frame_center"].values.astype(np.uint64) // cycle_len,
-        candidates_df["frame_start"].values.astype(np.uint64) // cycle_len,
-        candidates_df["frame_stop"].values.astype(np.uint64) // cycle_len,
-    )
-    return candidates
 
 
 def to_features_df(

--- a/alphadia/workflow/peptidecentric/optimization_handler.py
+++ b/alphadia/workflow/peptidecentric/optimization_handler.py
@@ -370,7 +370,7 @@ class OptimizationHandler:
             ),
         )
 
-        candidates_df = extraction_handler.select_candidates(
+        candidates = extraction_handler.select_candidates(
             self._dia_data,
             self._optlock.batch_library,
         )
@@ -378,7 +378,7 @@ class OptimizationHandler:
         if self._config["search"]["extraction_backend"] == "python":
             precursor_quantified_w_features_df, fragments_df = (
                 extraction_handler.score_and_quantify_candidates(
-                    candidates_df,
+                    candidates,
                     self._dia_data,
                     self._optlock.batch_library,
                 )
@@ -403,12 +403,12 @@ class OptimizationHandler:
             )
         else:
             precursor_w_features_df = extraction_handler.score_candidates(
-                candidates_df, self._dia_data, self._optlock.batch_library
+                candidates, self._dia_data, self._optlock.batch_library
             )
 
             precursor_quantified_df, fragments_df = (
                 extraction_handler.quantify_candidates(
-                    candidates_df,
+                    candidates,
                     None,
                     self._dia_data,
                     self._optlock.batch_library,
@@ -437,7 +437,7 @@ class OptimizationHandler:
             )
 
             _, precursor_df = extraction_handler.perform_fdr_and_filter_candidates(
-                self._optlock.features_df, candidates_df
+                self._optlock.features_df, candidates
             )
 
         self._reporter.log_string(

--- a/alphadia/workflow/peptidecentric/peptidecentric.py
+++ b/alphadia/workflow/peptidecentric/peptidecentric.py
@@ -216,7 +216,7 @@ class PeptideCentricWorkflow(base.WorkflowBase):
             ),
         )
 
-        candidates_df = extraction_handler.select_candidates(
+        candidates = extraction_handler.select_candidates(
             self.dia_data,
             self.spectral_library,
             apply_cutoff=True,
@@ -225,7 +225,7 @@ class PeptideCentricWorkflow(base.WorkflowBase):
         if self._config["search"]["extraction_backend"] == "python":
             precursor_quantified_w_features_df, fragments_df = (
                 extraction_handler.score_and_quantify_candidates(
-                    candidates_df, self.dia_data, self.spectral_library
+                    candidates, self.dia_data, self.spectral_library
                 )
             )
 
@@ -266,18 +266,18 @@ class PeptideCentricWorkflow(base.WorkflowBase):
             ]
 
         else:
-            precursor_w_features_df = extraction_handler.score_candidates(
-                candidates_df, self.dia_data, self.spectral_library
+            features_df = extraction_handler.score_candidates(
+                candidates, self.dia_data, self.spectral_library
             )
 
-            candidates_fdr_df, precursor_fdr_df = (
+            candidates_fdr, precursor_fdr_df = (
                 extraction_handler.perform_fdr_and_filter_candidates(
-                    precursor_w_features_df, candidates_df
+                    features_df, candidates
                 )
             )
 
             precursor_df, fragments_df = extraction_handler.quantify_candidates(
-                candidates_fdr_df,
+                candidates_fdr,
                 precursor_fdr_df,
                 self.dia_data,
                 self.spectral_library,


### PR DESCRIPTION
## Summary
- Keep candidates in Rust-native `CandidateCollection` through selection, scoring, FDR, and quantification stages
- Add Rust backend for z-score filtering (`zscore_filter_mask`) with numpy fallback
- Add `min_fragments_selection` config option for fragment count cutoff during selection
- Remove `candidates_to_ng` round-trip conversion; only convert to DataFrame at the final merge step

Stacked on #798 → integration PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## PR Stack
- **alphadia-search-rs:** [#118](https://github.com/MannLabs/alphadia-search-rs/pull/118) → [#119](https://github.com/MannLabs/alphadia-search-rs/pull/119)
- **alphadia:** [#798](https://github.com/MannLabs/alphadia/pull/798) → [#799](https://github.com/MannLabs/alphadia/pull/799) → [#800](https://github.com/MannLabs/alphadia/pull/800)