### PR TITLE
remove unused fragments from input during multiplexing

### DIFF
--- a/alphadia/libtransform/multiplex.py
+++ b/alphadia/libtransform/multiplex.py
@@ -58,6 +58,7 @@ class MultiplexLibrary(ProcessingStep):
             input.precursor_df = input.precursor_df[
                 input.precursor_df["channel"] == self._input_channel
             ]
+            input.remove_unused_fragments()
 
         channel_lib_list = []
         for channel, channel_mod_translations in self._multiplex_mapping.items():


### PR DESCRIPTION
fixes
```
  File "/fs/gpfs41/lv07/fileset03/home/b_mann/eikmeier/miniforge3/envs/alphadia/lib/python3.10/site-packages/alphadia/libtransform/multiplex.py", line 79, in forward
    speclib = reduce(lambda x, y: apply_func(x, y), channel_lib_list)
  File "/fs/gpfs41/lv07/fileset03/home/b_mann/eikmeier/miniforge3/envs/alphadia/lib/python3.10/site-packages/alphadia/libtransform/multiplex.py", line 79, in <lambda>
    speclib = reduce(lambda x, y: apply_func(x, y), channel_lib_list)
  File "/fs/gpfs41/lv07/fileset03/home/b_mann/eikmeier/miniforge3/envs/alphadia/lib/python3.10/site-packages/alphadia/libtransform/multiplex.py", line 76, in apply_func
    x.append(y)
  File "/fs/gpfs41/lv07/fileset03/home/b_mann/eikmeier/miniforge3/envs/alphadia/lib/python3.10/site-packages/alphabase/spectral_library/base.py", line 281, in append
    raise ValueError(
ValueError: The libraries can't be appended as the number of fragments in the current libraries are not the same.
```