### PR TITLE
add support for .mzML file selection in InputFileSelect component

### DIFF
--- a/gui/src/renderer/components/InputFileSelect.js
+++ b/gui/src/renderer/components/InputFileSelect.js
@@ -42,14 +42,7 @@ const InputFileSelect = ({
                 sx={{float: 'right', ml:1, minWidth: "115px", textTransform: 'none', minWidth: "50px"}}
                 disabled={!active}
                 onClick={handleRawSelect}>
-                .wiff
-            </Button>
-            <Button
-                variant="outlined"
-                sx={{float: 'right', ml:1, minWidth: "115px", textTransform: 'none', minWidth: "50px"}}
-                disabled={!active}
-                onClick={handleRawSelect}>
-                .raw
+                .raw | .wiff | .mzML
             </Button>
             <Button
                 variant="outlined"


### PR DESCRIPTION
Merge input file buttons and add mzML label
<img width="652" height="212" alt="image" src="https://github.com/user-attachments/assets/b78680f3-cb36-4c3a-a015-1efd8a4c341e" />

@GeorgWa : we could include a filter on the extension (such that users can only select e.g. .raw)?
