### PR TITLE
Add peptdeep_kontext / TTO support to the GUI

### DIFF
--- a/alphadia/constants/multistep.yaml
+++ b/alphadia/constants/multistep.yaml
@@ -28,6 +28,8 @@ library:
     enabled: False
   transfer_learning:
     enabled: False
+  context_extraction:
+    enabled: False
 # will be set in search_plan.py if transfer step is enabled:
 #  library_prediction:
 #    enabled: True
@@ -47,6 +49,8 @@ mbr:
   transfer_library:
     enabled: False
   transfer_learning:
+    enabled: False
+  context_extraction:
     enabled: False
 # will be set in search_plan.py if mbr step is enabled:
 #  library_path: <value from library step>

--- a/gui/src/renderer/components/WorkflowOverview.js
+++ b/gui/src/renderer/components/WorkflowOverview.js
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { useMethod } from '../logic/context'
 import { useMethodDispatch } from '../logic/context';
 import { Masonry } from '@mui/lab';
-import { Box, Typography, Switch, useTheme, List, ListItem, ListItemText, Stack } from '@mui/material';
+import { Box, Typography, Switch, useTheme, List, ListItem, ListItemText, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material';
 
 import ReactFlow, {
     ReactFlowProvider,
@@ -175,31 +175,64 @@ const InputNode = ({ data, id, onEnabledChange }) => {
     );
 };
 
-const TransferLearningNode = ({ data, id, onEnabledChange }) => {
+const TransferLearningNode = ({ data, id, onEnabledChange, onMethodChange }) => {
+    const method = data.adaptationMethod === "tto" ? "tto" : "transfer";
+    const description = method === "tto"
+        ? "Search all files and extract the context with peptdeep_kontext. Will be used for main search."
+        : "Search all files and train a custom PeptDeep model. Will be used for main search.";
+
+    const handleMethodChange = (event, newMethod) => {
+        // ToggleButtonGroup passes null when the active button is re-clicked; ignore to keep a selection.
+        if (newMethod !== null) {
+            onMethodChange(newMethod);
+        }
+    };
+
     return (
         <CustomNodeBase data={data} id={id} onEnabledChange={onEnabledChange} tooltipTitle={
                     <Stack spacing={0.5}>
-                        <Typography sx={{ fontWeight: 'bold' }}>Transfer Learning</Typography>
-                        <Typography sx={{ fontFamily: 'monospace' }}>{`[general.transfer_step_enabled]`}</Typography>
+                        <Typography sx={{ fontWeight: 'bold' }}>Adaptation</Typography>
+                        <Typography sx={{ fontFamily: 'monospace' }}>{`[general.transfer_step_enabled] [general.adaptation_method]`}</Typography>
                         <Typography>
-                            The transfer learning step will perform a whole search of all selected raw files before the first search. It can be used with a spectral library or with fasta files and fully predicted library.
+                            The adaptation step will perform a whole search of all selected raw files before the first search. It can be used with a spectral library or with fasta files and fully predicted library.
+                            <br/><br/>
+                            Two methods are available:
+                            <br/>
+                            &bull; <b>Transfer</b>: fine-tune a custom PeptDeep model (transfer learning).
+                            <br/>
+                            &bull; <b>TTO</b>: extract the context with peptdeep_kontext (test-time optimization).
                             <br/><br/>
                             All parameters set in the configuration will also be used for this step (except those required to switch on the specific behavior of this step).
                             <br/><br/>
-                            If this step is enabled, the transfer library module as well as transfer learning module will be automatically activated for this step:
+                            If this step is enabled, the relevant modules are automatically activated for this step:
                         </Typography>
                         <Typography sx={{ fontFamily: 'monospace' }}>
-                            transfer_library.enabled  = true<br/>
-                            transfer_learning.enabled = true
+                            {method === "tto"
+                                ? "context_extraction.enabled = true"
+                                : <>transfer_library.enabled  = true<br/>transfer_learning.enabled = true</>}
                         </Typography>
                         <Typography>
-                            The configuration section for transfer learning and transfer library offer advanced parameters to tune the behavior of the transfer learning step.
+                            The corresponding configuration section offers advanced parameters to tune the behavior of the adaptation step.
                         </Typography>
                     </Stack>
                 }
             >
-                <Typography variant="body2" sx={{paddingTop: 2, pointerEvents: 'auto'}}>
-                    Search all files and train custom PeptDeep model. Will be used for main search.
+                {data.enabled && (
+                    <Box sx={{ paddingTop: 2, pointerEvents: 'auto' }}>
+                        <ToggleButtonGroup
+                            value={method}
+                            exclusive
+                            size="small"
+                            onChange={handleMethodChange}
+                            fullWidth
+                        >
+                            <ToggleButton value="transfer" sx={{ textTransform: 'none', py: 0.25 }}>Transfer</ToggleButton>
+                            <ToggleButton value="tto" sx={{ textTransform: 'none', py: 0.25 }}>TTO</ToggleButton>
+                        </ToggleButtonGroup>
+                    </Box>
+                )}
+                <Typography variant="body2" sx={{paddingTop: data.enabled ? 1 : 2, pointerEvents: 'auto'}}>
+                    {description}
                 </Typography>
         </CustomNodeBase>
     );
@@ -267,9 +300,9 @@ const OutputNode = ({ data, id, onEnabledChange }) => {
 };
 
 // Update createNodeTypes to use the renamed component
-const createNodeTypes = (handleEnabledChange) => ({
+const createNodeTypes = (handleEnabledChange, handleMethodChange) => ({
     inputIO: (props) => <InputNode {...props} onEnabledChange={handleEnabledChange} />,
-    transferLearning: (props) => <TransferLearningNode {...props} onEnabledChange={handleEnabledChange} />,
+    transferLearning: (props) => <TransferLearningNode {...props} onEnabledChange={handleEnabledChange} onMethodChange={handleMethodChange} />,
     librarySearch: (props) => <LibrarySearchNode {...props} onEnabledChange={handleEnabledChange} />,
     matchBetweenRuns: (props) => <MatchBetweenRunsNode {...props} onEnabledChange={handleEnabledChange} />,
     outputIO: (props) => <OutputNode {...props} onEnabledChange={handleEnabledChange} />
@@ -280,7 +313,7 @@ const edgeTypes = {
     animated: AnimatedEdge,
 };
 
-const getNodesForNodeStates = (transferLearningEnabled, matchBetweenRunsEnabled) => {
+const getNodesForNodeStates = (transferLearningEnabled, matchBetweenRunsEnabled, adaptationMethod) => {
     return [
         {
             id: '1',
@@ -298,9 +331,10 @@ const getNodesForNodeStates = (transferLearningEnabled, matchBetweenRunsEnabled)
             id: '2',
             position: { x: X0 + DELTA, y: 75 },
             data: {
-                label: 'Transfer Learning',
+                label: 'Adaptation',
                 isSwitchable: true,
                 enabled: transferLearningEnabled,
+                adaptationMethod: adaptationMethod,
                 isSource: true,
                 isTarget: true
             },
@@ -390,9 +424,12 @@ const getWorkflowStates = (method) => {
     const matchBetweenRunsStep = generalParameterGroup.parameters.find(parameter => parameter.id === "mbr_step_enabled");
     const matchBetweenRunsStepEnabled = matchBetweenRunsStep.value;
 
+    const adaptationMethodParameter = generalParameterGroup.parameters.find(parameter => parameter.id === "adaptation_method");
+    const adaptationMethod = adaptationMethodParameter ? adaptationMethodParameter.value : "transfer";
+
     return {
         edges: getEdgesForNodeStates(transferLearningStepEnabled, matchBetweenRunsStepEnabled),
-        nodes: getNodesForNodeStates(transferLearningStepEnabled, matchBetweenRunsStepEnabled)
+        nodes: getNodesForNodeStates(transferLearningStepEnabled, matchBetweenRunsStepEnabled, adaptationMethod)
     };
 };
 
@@ -437,10 +474,19 @@ const WorkflowOverview = () => {
 
     };
 
+    const handleMethodChange = (method) => {
+        dispatch({
+            type: 'updateParameter',
+            parameterGroupId: "general",
+            parameterId: "adaptation_method",
+            value: method
+        })
+    };
+
     // Memoize the nodeTypes object
     const nodeTypes = React.useMemo(
-        () => createNodeTypes(handleEnabledChange),
-        [handleEnabledChange]
+        () => createNodeTypes(handleEnabledChange, handleMethodChange),
+        [handleEnabledChange, handleMethodChange]
     );
 
     return (

--- a/gui/src/renderer/components/WorkflowOverview.js
+++ b/gui/src/renderer/components/WorkflowOverview.js
@@ -178,8 +178,8 @@ const InputNode = ({ data, id, onEnabledChange }) => {
 const TransferLearningNode = ({ data, id, onEnabledChange, onMethodChange }) => {
     const method = data.adaptationMethod === "tto" ? "tto" : "transfer";
     const description = method === "tto"
-        ? "Search all files and extract the context with peptdeep_kontext. Will be used for main search."
-        : "Search all files and train a custom PeptDeep model. Will be used for main search.";
+        ? "Search all files and extract the context with peptdeep_kontext. The result will be used for the main search."
+        : "Search all files and train a custom PeptDeep model. The result will be used for the main search.";
 
     const handleMethodChange = (event, newMethod) => {
         // ToggleButtonGroup passes null when the active button is re-clicked; ignore to keep a selection.

--- a/gui/src/renderer/pages/Method.js
+++ b/gui/src/renderer/pages/Method.js
@@ -13,6 +13,25 @@ const FullWidthBox = styled(Box)(({ theme }) => ({
     marginBottom: '8px'
 }))
 
+// Resolve a "section_id.parameter_id" reference to its current value in the method config.
+const getParameterValue = (method, path) => {
+    const [groupId, parameterId] = path.split('.');
+    const group = method.config.find(g => g.id === groupId);
+    if (!group) return undefined;
+    const parameter = [...(group.parameters || []), ...(group.parameters_advanced || [])]
+        .find(p => p.id === parameterId);
+    return parameter ? parameter.value : undefined;
+}
+
+// A section without `visible_when` is always shown. Otherwise every referenced
+// parameter must equal its expected value for the section to render.
+const isSectionVisible = (section, method) => {
+    if (!section.visible_when) return true;
+    return Object.entries(section.visible_when).every(
+        ([path, expected]) => getParameterValue(method, path) === expected
+    );
+}
+
 const Files = () => {
     const method = useMethod();
     const dispatch = useMethodDispatch();
@@ -112,7 +131,9 @@ const Config = () => {
                 />
             </Box>
             <Masonry columns={{ xs: 1, sm: 2, md: 2, lg: 3, xl: 3 }} spacing={1}>
-                {method.config.map((parameterGroup, index) => (
+                {method.config
+                    .filter(parameterGroup => isSectionVisible(parameterGroup, method))
+                    .map((parameterGroup, index) => (
                 <ParameterGroup
                     key={parameterGroup.id}
                     parameterGroup={parameterGroup}

--- a/gui/workflows/PeptideCentric.v1.json
+++ b/gui/workflows/PeptideCentric.v1.json
@@ -390,14 +390,14 @@
                     "id": "peptdeep_model_path",
                     "name": "PeptDeep Model Path",
                     "default": null,
-                    "description": "Select a custom PeptDeep model for library prediction. This can be a DDA or DIA trained model. Please make sure that you use the same instrument type and NCE for prediction as the model was trained on. If empty, a generic model provided by peptdeep will be used.",
+                    "description": "Custom PeptDeep model for library prediction. Relevant when using 'peptdeep' as the Prediction Framework, or when running the Transfer Learning adaptation method. This can be a DDA or DIA trained model; make sure to use the same instrument type and NCE for prediction as the model was trained on. If empty, a generic model provided by peptdeep is used.",
                     "type": "singleFolderSelection"
                 },
                 {
                     "id": "peptdeep_model_type",
                     "name": "PeptDeep Model Type",
                     "default": "generic",
-                    "description": "Select a custom pretrained PeptDeep model for library prediction. Possible defaults are 'generic', 'phospho' and 'digly'.",
+                    "description": "Pretrained PeptDeep model type for library prediction. Relevant when using 'peptdeep' as the Prediction Framework, or when running the Transfer Learning adaptation method. Possible values are 'generic', 'phospho' and 'digly'.",
                     "type": "dropdown",
                     "options": [
                         "generic",
@@ -407,16 +407,16 @@
                 },
                 {
                     "id": "peptdeep_kontext_model_path",
-                    "name": "Kontext Model Path",
+                    "name": "Peptdeep_Kontext Model Path",
                     "default": null,
-                    "description": "peptdeep_kontext downstream (ContextDownstream) model directory used when Prediction Framework is 'peptdeep_kontext'. If empty, the weights are auto-downloaded to ~/.cache/peptdeep_kontext.",
+                    "description": "peptdeep_kontext downstream (ContextDownstream) model directory. Relevant when using 'peptdeep_kontext' as the Prediction Framework, or when running the TTO adaptation method. If empty, the weights are auto-downloaded to ~/.cache/peptdeep_kontext.",
                     "type": "singleFolderSelection"
                 },
                 {
                     "id": "context_path",
-                    "name": "Context Path",
+                    "name": "Peptdeep_Kontext Experiment Context Path",
                     "default": null,
-                    "description": "Path to the context used for peptdeep_kontext library prediction. If empty, a zero context is used. In a multistep TTO run this is set automatically from the adaptation step output.",
+                    "description": "Path to the experiment context used for peptdeep_kontext library prediction. Relevant when using 'peptdeep_kontext' as the Prediction Framework. If empty, a zero context is used. In a multistep TTO run this is set automatically from the adaptation step output, so you do not need to set it here.",
                     "type": "singleFolderSelection"
                 }
             ]

--- a/gui/workflows/PeptideCentric.v1.json
+++ b/gui/workflows/PeptideCentric.v1.json
@@ -49,6 +49,18 @@
                     "description": "Whether to perform a 'second search' step after the first search. All parameters set here will also be used for this step (except those required to switch on the specific behaviour of this step).",
                     "type": "boolean",
                     "hidden": true
+                },
+                {
+                    "id": "adaptation_method",
+                    "name": "Adaptation Method",
+                    "default": "transfer",
+                    "description": "Method for the adaptation step: 'transfer' (peptdeep fine-tuning) or 'tto' (peptdeep_kontext test-time optimization). Selected via the Adaptation node in the workflow overview.",
+                    "type": "dropdown",
+                    "options": [
+                        "transfer",
+                        "tto"
+                    ],
+                    "hidden": true
                 }
             ],
             "parameters_advanced": [
@@ -190,6 +202,17 @@
                     "default": false,
                     "description": "Use alphaPeptDeep to predict peptide. \n If a FASTA file is provided an in silico digest will be performed. \n If a spectral library is provided precursor properties for library precursor will be performed.",
                     "type": "boolean"
+                },
+                {
+                    "id": "prediction_framework",
+                    "name": "Prediction Framework",
+                    "default": "peptdeep",
+                    "description": "Framework used for library prediction. \n 'peptdeep' uses alphaPeptDeep. \n 'peptdeep_kontext' uses the peptdeep_kontext models (see the Kontext Model Path and Context Path in the advanced parameters). \n Note: when a multistep TTO adaptation step is enabled, this is set automatically for the main search.",
+                    "type": "dropdown",
+                    "options": [
+                        "peptdeep",
+                        "peptdeep_kontext"
+                    ]
                 },
                 {
                     "id": "enzyme",
@@ -381,6 +404,20 @@
                         "phospho",
                         "digly"
                     ]
+                },
+                {
+                    "id": "peptdeep_kontext_model_path",
+                    "name": "Kontext Model Path",
+                    "default": null,
+                    "description": "peptdeep_kontext downstream (ContextDownstream) model directory used when Prediction Framework is 'peptdeep_kontext'. If empty, the weights are auto-downloaded to ~/.cache/peptdeep_kontext.",
+                    "type": "singleFolderSelection"
+                },
+                {
+                    "id": "context_path",
+                    "name": "Context Path",
+                    "default": null,
+                    "description": "Path to the context used for peptdeep_kontext library prediction. If empty, a zero context is used. In a multistep TTO run this is set automatically from the adaptation step output.",
+                    "type": "singleFolderSelection"
                 }
             ]
         },
@@ -595,6 +632,9 @@
             "id": "transfer_library",
             "name": "Transfer Library",
             "hidden": true,
+            "visible_when": {
+                "general.transfer_step_enabled": true
+            },
             "parameters": [
                 {
                     "id": "enabled",
@@ -657,6 +697,10 @@
             "id": "transfer_learning",
             "name": "Transfer Learning",
             "hidden": true,
+            "visible_when": {
+                "general.transfer_step_enabled": true,
+                "general.adaptation_method": "transfer"
+            },
             "parameters": [
                 {
                     "id": "enabled",
@@ -748,6 +792,86 @@
                         "Velos", "Elite", "OrbitrapTribrid", "ThermoTribrid", "QE+",
                         "QEHF", "QEHFX", "Exploris", "Exploris480"
                     ]
+                }
+            ]
+        },
+        {
+            "id": "context_extraction",
+            "name": "Context Extraction",
+            "hidden": true,
+            "visible_when": {
+                "general.transfer_step_enabled": true,
+                "general.adaptation_method": "tto"
+            },
+            "parameters": [
+                {
+                    "id": "enabled",
+                    "name": "Enabled for all steps",
+                    "default": false,
+                    "description": "If true, peptdeep_kontext test-time optimization (TTO) is used to extract the context and predict the library. The settings in this section will be used for all steps. If you are using a multistep workflow with the 'tto' adaptation method, this option is automatically enabled for the adaptation step. Only use this section to configure individual settings but do not activate this option for all steps.",
+                    "type": "boolean"
+                }
+            ],
+            "parameters_advanced": [
+                {
+                    "id": "tto_epochs",
+                    "name": "TTO epochs",
+                    "default": 10,
+                    "description": "Number of epochs used to extract the context during TTO.",
+                    "type": "integer"
+                },
+                {
+                    "id": "tto_warmup_epochs",
+                    "name": "TTO warmup epochs",
+                    "default": 5,
+                    "description": "Number of warmup epochs during which the learning rate is ramped up during TTO.",
+                    "type": "integer"
+                },
+                {
+                    "id": "tto_batch_size",
+                    "name": "TTO batch size",
+                    "default": 2000,
+                    "description": "Number of precursors per batch during TTO.",
+                    "type": "integer"
+                },
+                {
+                    "id": "tto_lr",
+                    "name": "TTO learning rate",
+                    "default": 0.1,
+                    "description": "Maximum learning rate per batch during TTO. The maximum learning rate will be reached after a warmup phase.",
+                    "type": "float"
+                },
+                {
+                    "id": "context_model_path",
+                    "name": "Context Model Path",
+                    "default": null,
+                    "description": "Path to the pretrained peptdeep_kontext ContextModel directory. If empty, the weights are auto-downloaded to ~/.cache/peptdeep_kontext.",
+                    "type": "singleFolderSelection"
+                },
+                {
+                    "id": "context_model_version",
+                    "name": "Context Model Version",
+                    "default": "v2",
+                    "description": "Version tag used when auto-downloading peptdeep_kontext model weights.",
+                    "type": "string"
+                },
+                {
+                    "id": "fragment_types",
+                    "name": "Fragment types",
+                    "default": ["b", "y"],
+                    "description": "List of fragment types to quantify in the library.",
+                    "type": "multi_select",
+                    "options": [
+                        "b", "y", "b_modloss", "y_modloss", "a", "c", "x", "z",
+                        "b_H2O", "y_H2O", "b_NH3", "y_NH3", "c_lossH", "z_addH"
+                    ]
+                },
+                {
+                    "id": "max_charge",
+                    "name": "Maximum charge",
+                    "default": 2,
+                    "description": "Maximum charge for fragments.",
+                    "type": "integer"
                 }
             ]
         }


### PR DESCRIPTION
<!--
  Briefly describe the changes your PR makes.
  Include any info that might be relevant for reviewers to understand the context.
-->

Exposes the peptdeep_kontext integration in the GUI so users can select the TTO adaptation method, tune its parameters, and run kontext library prediction — none of which was reachable before.

**Changes**

- PeptideCentric.v1.json — added general.adaptation_method (transfer/tto), library_prediction.prediction_framework as a primary dropdown (+ kontext model/context paths in advanced), and a new context_extraction section for the TTO params.
- WorkflowOverview.js — renamed the node to "Adaptation" with a Transfer / TTO toggle.
- Method.js — conditional section visibility: only the sections relevant to the chosen method show (Transfer → Transfer Library + Transfer Learning; TTO → Transfer Library + Context Extraction).
- multistep.yaml — force-disable context_extraction in the library/mbr steps so it only runs in the adaptation step.



---

#### To-do list (outside contributers only)
- [ ] I have read and agree to the [MannLabs Contributor License Agreement](https://github.com/MannLabs/.github/blob/main/CLA.md)