### PR TITLE
Wire real cycle_fwhm from the rust backend into the NG extraction path

### DIFF
--- a/alphadia/workflow/peptidecentric/extraction_handler.py
+++ b/alphadia/workflow/peptidecentric/extraction_handler.py
@@ -631,9 +631,7 @@ class NgExtractionHandler(ExtractionHandler):
 
         if precursor_fdr_df is not None:
             precursor_df = precursor_df.merge(
-                precursor_fdr_df[
-                    ["precursor_idx", "rank", "qval", "proba", "cycle_fwhm"]
-                ],
+                precursor_fdr_df[["precursor_idx", "rank", "qval", "proba"]],
                 on=["precursor_idx", "rank"],
                 how="left",
             )

--- a/alphadia/workflow/peptidecentric/extraction_handler.py
+++ b/alphadia/workflow/peptidecentric/extraction_handler.py
@@ -631,7 +631,9 @@ class NgExtractionHandler(ExtractionHandler):
 
         if precursor_fdr_df is not None:
             precursor_df = precursor_df.merge(
-                precursor_fdr_df[["precursor_idx", "rank", "qval", "proba"]],
+                precursor_fdr_df[
+                    ["precursor_idx", "rank", "qval", "proba", "cycle_fwhm"]
+                ],
                 on=["precursor_idx", "rank"],
                 how="left",
             )
@@ -653,8 +655,6 @@ class NgExtractionHandler(ExtractionHandler):
             precursor_mz_column=self._column_name_handler.get_precursor_mz_column(),
         )
 
-        # TODO: get this from the ng backend
-        features_or_precursor_df["cycle_fwhm"] = 3  # TODO: remove
         features_or_precursor_df[CalibCols.MZ_OBSERVED] = features_or_precursor_df[
             CalibCols.MZ_LIBRARY
         ]  # required for transfer library building

--- a/alphadia/workflow/peptidecentric/ng/ng_mapper.py
+++ b/alphadia/workflow/peptidecentric/ng/ng_mapper.py
@@ -86,10 +86,7 @@ def speclib_to_ng(
 
 def get_feature_names() -> list[str]:
     """Get feature names from NG CandidateFeatureCollection."""
-    blacklist = ["fwhm_rt"]  # TODO: remove
-    return [
-        f for f in CandidateFeatureCollection.get_feature_names() if f not in blacklist
-    ]
+    return list(CandidateFeatureCollection.get_feature_names())
 
 
 def parse_candidates(
@@ -185,8 +182,6 @@ def to_features_df(
         on="precursor_idx",
         how="left",
     )
-
-    features_df.rename(columns={"fwhm_rt": "cycle_fwhm"}, inplace=True)
 
     return features_df
 


### PR DESCRIPTION
Uses the backend-computed `cycle_fwhm` instead of the hardcoded placeholder.

- `ng_mapper.get_feature_names()`: drops the `fwhm_rt` blacklist, so the feature reaches the FDR classifier.
- `ng_mapper.to_features_df()`: drops the `fwhm_rt` -> `cycle_fwhm` rename, which the backend now emits under the final name (MannLabs/alphadia-search-rs#128).
- `extraction_handler.NgExtractionHandler`: removes `features_or_precursor_df["cycle_fwhm"] = 3` and carries `cycle_fwhm` through the post-FDR merge, since it is a scoring feature and not produced by quantification.

Requires MannLabs/alphadia-search-rs#128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)