### PR TITLE
Use Rust FDR kernels in perform_fdr with exact tie-break handling

### DIFF
--- a/alphadia/fdr/fdr.py
+++ b/alphadia/fdr/fdr.py
@@ -289,6 +289,35 @@ def _fdr_to_q_values(fdr_values: np.ndarray) -> np.ndarray:
     return np.flip(q_values_flipped)
 
 
+def _integer_tiebreak(values: pd.Series) -> np.ndarray:
+    """Map a tie-break column to integer keys that sort like the column itself.
+
+    The Rust q-value kernel takes an integer tie-break key, but not every caller
+    breaks ties on an integer: protein FDR sorts by the protein-group accession, a
+    string. Factorizing with `sort=True` numbers the unique values in sorted order,
+    so ordering by the codes reproduces ordering by the original values and the
+    kernel stays exact for any sortable dtype.
+
+    Parameters
+    ----------
+    values : pd.Series
+        The tie-break column.
+
+    Returns
+    -------
+    np.ndarray
+        int64 keys with the same ordering as `values`.
+
+    """
+    if pd.api.types.is_integer_dtype(values):
+        return values.to_numpy(dtype=np.int64)
+
+    codes, _ = pd.factorize(values, sort=True)
+    # factorize codes missing values as -1, which would sort them first; pandas
+    # sorts them last.
+    return np.where(codes < 0, np.iinfo(np.int64).max, codes).astype(np.int64)
+
+
 def get_q_values(
     df: pd.DataFrame,
     score_column: str = "proba",
@@ -326,18 +355,13 @@ def get_q_values(
     if extra_sort_columns is None:
         extra_sort_columns = ["precursor_idx"]
 
-    # The Rust kernel requires an integer tie-break key. Precursor FDR sorts by
-    # `precursor_idx` (integer), but protein FDR sorts by the protein-group accession
-    # (a string), so fall back to the reference pandas path for non-integer columns.
-    if (
-        _USE_RUST_FDR
-        and len(extra_sort_columns) == 1
-        and pd.api.types.is_integer_dtype(df[extra_sort_columns[0]])
-    ):
+    # The Rust kernel takes a single tie-break key, so multi-column tie-breaks stay
+    # on the reference path.
+    if _USE_RUST_FDR and len(extra_sort_columns) == 1:
         order, qvalues = _rs_q_values(
             df[score_column].to_numpy(dtype=np.float64),
             df[decoy_column].to_numpy(dtype=np.float64),
-            df[extra_sort_columns[0]].to_numpy(dtype=np.int64),
+            _integer_tiebreak(df[extra_sort_columns[0]]),
         )
         df = df.iloc[order].copy()
         df[qval_column] = qvalues

--- a/alphadia/fdr/fdr.py
+++ b/alphadia/fdr/fdr.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -19,6 +20,23 @@ if TYPE_CHECKING:
 max_dia_cycle_shape = 2
 
 logger = logging.getLogger()
+
+try:
+    from alphadia_search_rs import fdr_finalize as _rs_finalize
+    from alphadia_search_rs import fdr_keep_best as _rs_keep_best
+    from alphadia_search_rs import fdr_q_values as _rs_q_values
+
+    _RUST_FDR_AVAILABLE = True
+except ImportError:
+    _RUST_FDR_AVAILABLE = False
+
+# Rust-accelerated q-value/keep-best kernels are used by default when available.
+# Set ALPHADIA_RUST_FDR=0 to force the reference pandas implementation (for A/B benchmarking).
+_USE_RUST_FDR = _RUST_FDR_AVAILABLE and os.environ.get("ALPHADIA_RUST_FDR", "1") != "0"
+
+# Bin resolution for the sort-free histogram q-value estimation. 2**20 bins over
+# proba in [0, 1] gives ~1e-6 resolution, far finer than any FDR threshold.
+_FDR_QVALUE_BINS = 1 << 20
 
 
 @manage_torch_threads(max_threads=2)
@@ -148,32 +166,48 @@ def perform_fdr(  # noqa: C901, PLR0913, PLR0915 # too complex, Too many stateme
     predicted_proba = classifier.predict_proba(X)[:, 1]
 
     psm_df["proba"] = predicted_proba
-    psm_df.sort_values(
-        ["proba", "precursor_idx"], ascending=True, inplace=True
-    )  # last sort to break ties
 
-    psm_df = get_q_values(psm_df, "proba", "_decoy")
+    do_fragment_competition = (
+        dia_cycle is not None
+        and dia_cycle.shape[2] <= max_dia_cycle_shape
+        and df_fragments is not None
+    )
 
-    if dia_cycle is not None and dia_cycle.shape[2] <= max_dia_cycle_shape:
-        # use a FDR of 10% as starting point
-        # if there are no PSMs with a FDR < 10% use all PSMs
-        start_idx = psm_df["qval"].searchsorted(fdr_heuristic, side="left")
-        if start_idx == 0:
-            start_idx = len(psm_df)
+    if _USE_RUST_FDR and not do_fragment_competition:
+        # Fused sort-free finalization: keep-best per group and q-values are
+        # computed in a single counting pass (no full sort, no O(N) ordering).
+        group_id = (
+            psm_df.groupby(group_columns, sort=False).ngroup().to_numpy(dtype=np.int64)
+        )
+        order, qvalues = _rs_finalize(
+            psm_df["proba"].to_numpy(dtype=np.float64),
+            psm_df["_decoy"].to_numpy(dtype=np.float64),
+            group_id,
+            _FDR_QVALUE_BINS,
+        )
+        psm_df = psm_df.iloc[order].copy()
+        psm_df["qval"] = qvalues
+    else:
+        psm_df.sort_values(
+            ["proba", "precursor_idx"], ascending=True, inplace=True
+        )  # last sort to break ties
 
-        # make sure fragments are not reused
-        if df_fragments is not None:
-            if dia_cycle is None:
-                raise ValueError(
-                    "dia_cycle must be provided if df_fragments is provided"
-                )
+        psm_df = get_q_values(psm_df, "proba", "_decoy")
+
+        if do_fragment_competition:
+            # use a FDR of 10% as starting point
+            # if there are no PSMs with a FDR < 10% use all PSMs
+            start_idx = psm_df["qval"].searchsorted(fdr_heuristic, side="left")
+            if start_idx == 0:
+                start_idx = len(psm_df)
+
             fragment_competition = FragmentCompetition()
             psm_df = fragment_competition(
                 psm_df.iloc[:start_idx], df_fragments, dia_cycle
             )
 
-    psm_df = keep_best(psm_df, group_columns=group_columns)
-    psm_df = get_q_values(psm_df, "proba", "_decoy")
+        psm_df = keep_best(psm_df, group_columns=group_columns)
+        psm_df = get_q_values(psm_df, "proba", "_decoy")
 
     if figure_path is not None:
         plot_fdr(
@@ -218,6 +252,14 @@ def keep_best(
     if group_columns is None:
         group_columns = ["channel", "precursor_idx"]
     df = df.reset_index(drop=True)
+
+    if _USE_RUST_FDR:
+        group_id = (
+            df.groupby(group_columns, sort=False).ngroup().to_numpy(dtype=np.int64)
+        )
+        keep = _rs_keep_best(df[score_column].to_numpy(dtype=np.float64), group_id)
+        return df.iloc[keep].reset_index(drop=True)
+
     df = df.sort_values(
         [score_column, *group_columns], ascending=True
     )  # last sort to break ties
@@ -283,6 +325,16 @@ def get_q_values(
     """
     if extra_sort_columns is None:
         extra_sort_columns = ["precursor_idx"]
+
+    if _USE_RUST_FDR and len(extra_sort_columns) == 1:
+        order, qvalues = _rs_q_values(
+            df[score_column].to_numpy(dtype=np.float64),
+            df[decoy_column].to_numpy(dtype=np.float64),
+            df[extra_sort_columns[0]].to_numpy(dtype=np.int64),
+        )
+        df = df.iloc[order].copy()
+        df[qval_column] = qvalues
+        return df
 
     df = df.sort_values(
         [score_column, decoy_column, *extra_sort_columns], ascending=True

--- a/alphadia/fdr/fdr.py
+++ b/alphadia/fdr/fdr.py
@@ -326,7 +326,14 @@ def get_q_values(
     if extra_sort_columns is None:
         extra_sort_columns = ["precursor_idx"]
 
-    if _USE_RUST_FDR and len(extra_sort_columns) == 1:
+    # The Rust kernel requires an integer tie-break key. Precursor FDR sorts by
+    # `precursor_idx` (integer), but protein FDR sorts by the protein-group accession
+    # (a string), so fall back to the reference pandas path for non-integer columns.
+    if (
+        _USE_RUST_FDR
+        and len(extra_sort_columns) == 1
+        and pd.api.types.is_integer_dtype(df[extra_sort_columns[0]])
+    ):
         order, qvalues = _rs_q_values(
             df[score_column].to_numpy(dtype=np.float64),
             df[decoy_column].to_numpy(dtype=np.float64),

--- a/tests/unit_tests/fdr/test_fdr.py
+++ b/tests/unit_tests/fdr/test_fdr.py
@@ -109,6 +109,48 @@ def test_get_q_values():
     )
 
 
+def test_integer_tiebreak_preserves_integer_column():
+    # Given: an integer tie-break column
+    values = pd.Series([7, 3, 3, 11], dtype="int64")
+
+    # When: mapping it to kernel tie-break keys
+    keys = fdr._integer_tiebreak(values)
+
+    # Then: the values are passed through unchanged
+    np.testing.assert_array_equal(keys, np.array([7, 3, 3, 11], dtype=np.int64))
+
+
+def test_integer_tiebreak_reproduces_string_sort_order():
+    # Given: a string tie-break column, as protein FDR uses for the protein group
+    test_df = pd.DataFrame(
+        {
+            "proba": [0.1] * 5,
+            "decoy": [0.0] * 5,
+            "pg": ["Q9Y6K9", "A0A024", "P12345", "B2RXH2", "A0A024"],
+        }
+    )
+
+    # When: sorting by the tie-break keys instead of by the strings
+    by_string = test_df.sort_values(["proba", "decoy", "pg"]).index.tolist()
+    test_df["key"] = fdr._integer_tiebreak(test_df["pg"])
+    by_key = test_df.sort_values(["proba", "decoy", "key"]).index.tolist()
+
+    # Then: both orderings agree, so the kernel stays exact on string columns
+    assert by_key == by_string
+
+
+def test_integer_tiebreak_sorts_missing_values_last():
+    # Given: a tie-break column with a missing value
+    values = pd.Series(["B", None, "A"])
+
+    # When: mapping it to kernel tie-break keys
+    keys = fdr._integer_tiebreak(values)
+
+    # Then: the missing value sorts last, as it does in pandas
+    assert keys[1] == np.iinfo(np.int64).max
+    assert list(np.argsort(keys, kind="stable")) == [2, 0, 1]
+
+
 def gen_data_np(
     n_features=10,
     n_samples=10000,

--- a/tests/unit_tests/fdr/test_fdr_rust_parity.py
+++ b/tests/unit_tests/fdr/test_fdr_rust_parity.py
@@ -1,0 +1,95 @@
+"""Parity tests: Rust-accelerated FDR kernels vs the pandas reference."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from alphadia.fdr import fdr
+
+if not fdr._RUST_FDR_AVAILABLE:
+    pytest.skip("alphadia_search_rs FDR kernels not available", allow_module_level=True)
+
+
+def _make_psms(n: int, seed: int = 0) -> pd.DataFrame:
+    """Synthetic PSMs with distinct probas, target/decoy labels, and group ids."""
+    rng = np.random.default_rng(seed)
+    # distinct probas to avoid tie-ordering ambiguity between sort and counting
+    proba = rng.permutation(np.linspace(0.0, 1.0, n, endpoint=False))
+    decoy = (rng.random(n) < 0.4).astype(float)
+    return pd.DataFrame(
+        {
+            "proba": proba,
+            "_decoy": decoy,
+            "precursor_idx": np.arange(n),
+            "elution_group_idx": rng.integers(0, n // 2 + 1, n),
+            "channel": rng.integers(0, 2, n),
+        }
+    )
+
+
+def _run(monkeypatch, use_rust: bool, fn, *args, **kwargs):
+    monkeypatch.setattr(fdr, "_USE_RUST_FDR", use_rust and fdr._RUST_FDR_AVAILABLE)
+    return fn(*args, **kwargs)
+
+
+def test_get_q_values_matches_reference(monkeypatch):
+    df = _make_psms(50_000)
+
+    rust = _run(monkeypatch, True, fdr.get_q_values, df.copy(), "proba", "_decoy")
+    ref = _run(monkeypatch, False, fdr.get_q_values, df.copy(), "proba", "_decoy")
+
+    rust = rust.sort_values("precursor_idx").reset_index(drop=True)
+    ref = ref.sort_values("precursor_idx").reset_index(drop=True)
+
+    np.testing.assert_allclose(
+        rust["qval"].to_numpy(), ref["qval"].to_numpy(), atol=1e-12
+    )
+
+
+@pytest.mark.parametrize(
+    "group_columns",
+    [["precursor_idx"], ["channel", "elution_group_idx"], ["elution_group_idx"]],
+)
+def test_keep_best_matches_reference(monkeypatch, group_columns):
+    df = _make_psms(50_000)
+
+    rust = _run(monkeypatch, True, fdr.keep_best, df.copy(), "proba", group_columns)
+    ref = _run(monkeypatch, False, fdr.keep_best, df.copy(), "proba", group_columns)
+
+    rust_idx = set(rust["precursor_idx"]) if "precursor_idx" in rust else None
+    # compare the set of retained rows by their unique precursor_idx
+    assert sorted(rust["precursor_idx"]) == sorted(ref["precursor_idx"])
+    assert rust_idx is not None
+
+
+def test_fused_finalize_threshold_counts_match_reference(monkeypatch):
+    """The fused histogram path should agree with the exact pandas chain on the
+    number of PSMs passing common FDR thresholds (within quantization noise)."""
+    df = _make_psms(200_000)
+    group_columns = ["elution_group_idx", "channel"]
+
+    # exact pandas reference: keep_best -> q-values
+    ref = _run(monkeypatch, False, fdr.keep_best, df.copy(), "proba", group_columns)
+    ref = _run(monkeypatch, False, fdr.get_q_values, ref, "proba", "_decoy")
+
+    # fused sort-free rust path
+    group_id = df.groupby(group_columns, sort=False).ngroup().to_numpy(dtype=np.int64)
+    order, qvalues = fdr._rs_finalize(
+        df["proba"].to_numpy(dtype=np.float64),
+        df["_decoy"].to_numpy(dtype=np.float64),
+        group_id,
+        fdr._FDR_QVALUE_BINS,
+    )
+    fused = df.iloc[order].copy()
+    fused["qval"] = qvalues
+
+    # same survivors after keep-best
+    assert sorted(fused["precursor_idx"]) == sorted(ref["precursor_idx"])
+
+    for thresh in (0.001, 0.01, 0.05):
+        n_ref = int((ref["qval"] < thresh).sum())
+        n_fused = int((fused["qval"] < thresh).sum())
+        # quantization tolerance: at most a handful of rows near the boundary
+        assert abs(n_ref - n_fused) <= max(
+            2, int(0.001 * n_ref)
+        ), f"thresh={thresh}: ref={n_ref} fused={n_fused}"

--- a/tests/unit_tests/fdr/test_fdr_rust_parity.py
+++ b/tests/unit_tests/fdr/test_fdr_rust_parity.py
@@ -46,6 +46,46 @@ def test_get_q_values_matches_reference(monkeypatch):
     )
 
 
+def test_get_q_values_string_tiebreak_matches_reference(monkeypatch):
+    """Protein FDR breaks ties on the protein group accession, a string column."""
+    rng = np.random.default_rng(1)
+    n = 20_000
+    df = pd.DataFrame(
+        {
+            # deliberate proba ties, so the tie-break column decides the ordering
+            "proba": rng.choice(np.linspace(0.0, 1.0, n // 10), n),
+            "decoy": (rng.random(n) < 0.4).astype(float),
+            "pg": [f"P{i:06d}" for i in rng.permutation(n)],
+        }
+    )
+
+    rust = _run(
+        monkeypatch,
+        True,
+        fdr.get_q_values,
+        df.copy(),
+        "proba",
+        "decoy",
+        extra_sort_columns=["pg"],
+    )
+    ref = _run(
+        monkeypatch,
+        False,
+        fdr.get_q_values,
+        df.copy(),
+        "proba",
+        "decoy",
+        extra_sort_columns=["pg"],
+    )
+
+    rust = rust.sort_values("pg").reset_index(drop=True)
+    ref = ref.sort_values("pg").reset_index(drop=True)
+
+    np.testing.assert_allclose(
+        rust["qval"].to_numpy(), ref["qval"].to_numpy(), atol=1e-12
+    )
+
+
 @pytest.mark.parametrize(
     "group_columns",
     [["precursor_idx"], ["channel", "elution_group_idx"], ["elution_group_idx"]],


### PR DESCRIPTION
Uses the Rust FDR kernels for the hot spots in `perform_fdr`, keeping the pandas implementation as the reference path:

- `fdr_q_values` / `fdr_keep_best` replace the pandas multi-key sort + cumsum + groupby in `get_q_values` and `keep_best`.
- `fdr_finalize` replaces the `sort -> get_q_values -> keep_best -> get_q_values` chain with a single counting pass, used when fragment competition is not required.
- `ALPHADIA_RUST_FDR=0` forces the reference path for A/B benchmarking, and it is also used automatically when the kernels are unavailable.

`get_q_values` needs an integer tie-break key for the kernel. Precursor FDR breaks ties on `precursor_idx`, but protein FDR breaks ties on `pg`, a string accession. Rather than branching on the column's dtype, `_integer_tiebreak` factorizes non-integer columns with `sort=True`, which numbers the unique values in sorted order, so ordering by the codes reproduces ordering by the original values and the kernel stays exact for any sortable dtype. Missing values map to the largest key so they sort last, as pandas sorts them.

Requires MannLabs/alphadia-search-rs#130. Until those kernels ship in a released `alphadia-search-rs`, `_RUST_FDR_AVAILABLE` is False, the reference path runs, and `test_fdr_rust_parity.py` skips.

Replaces #820, which was stacked on an unreviewed branch; this branch is cut from a clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)