### PR TITLE
Port FragmentCompetition to Rust

### DIFF
--- a/alphadia/fdr/_fdrx/base.py
+++ b/alphadia/fdr/_fdrx/base.py
@@ -15,7 +15,7 @@ from alphadia.fdr._fdrx.plotting import (
 )
 from alphadia.fdr._fdrx.stats import add_q_values, get_pep, keep_best
 from alphadia.fdr.utils import train_test_split_
-from alphadia.fragcomp.fragcomp import FragmentCompetition
+from alphadia.fragcomp.fragcomp import compete_for_fragments
 
 logger = logging.getLogger()
 
@@ -149,8 +149,7 @@ class TargetDecoyFDR:
                 decoy_column=self._decoy_column,
                 r_target_decoy=r_target_decoy,
             )
-            fragment_competition = FragmentCompetition()
-            psm_df = fragment_competition(
+            psm_df = compete_for_fragments(
                 psm_df[psm_df["qval"] < competition_heuristic], fragments_df, dia_cycle
             )
 

--- a/alphadia/fdr/fdr.py
+++ b/alphadia/fdr/fdr.py
@@ -11,7 +11,7 @@ import pandas as pd
 from alphadia.exceptions import TooFewPSMError
 from alphadia.fdr.plotting import plot_fdr
 from alphadia.fdr.utils import manage_torch_threads, train_test_split_
-from alphadia.fragcomp.fragcomp import FragmentCompetition
+from alphadia.fragcomp.fragcomp import compete_for_fragments
 
 if TYPE_CHECKING:
     from alphadia.fdr.classifiers import Classifier
@@ -22,7 +22,7 @@ logger = logging.getLogger()
 
 
 @manage_torch_threads(max_threads=2)
-def perform_fdr(  # noqa: C901, PLR0913, PLR0915 # too complex, Too many statements, too many arguments
+def perform_fdr(  # noqa: C901, PLR0913 # too complex, too many arguments
     classifier: Classifier,
     available_columns: list[str],
     df_target: pd.DataFrame,
@@ -167,8 +167,7 @@ def perform_fdr(  # noqa: C901, PLR0913, PLR0915 # too complex, Too many stateme
                 raise ValueError(
                     "dia_cycle must be provided if df_fragments is provided"
                 )
-            fragment_competition = FragmentCompetition()
-            psm_df = fragment_competition(
+            psm_df = compete_for_fragments(
                 psm_df.iloc[:start_idx], df_fragments, dia_cycle
             )
 

--- a/alphadia/fragcomp/fragcomp.py
+++ b/alphadia/fragcomp/fragcomp.py
@@ -1,9 +1,8 @@
 """The fragment competition module contains functionality to maintain the exclusive assignment of signal to identifications.
 
-Thin Python wrapper around the Rust fragment-competition kernel
-(`alphadia_search_rs.FragmentCompetition`). The numeric sweep (per-DIA-window
-fragment-overlap comparison) lives in Rust; this wrapper only prepares the
-candidate/fragment index bookkeeping and dataframe I/O.
+The numeric work — DIA-window assignment, priority ranking and the fragment-overlap
+sweep — lives in Rust (`alphadia_search_rs.FragmentCompetition`). This module only
+prepares the candidate/fragment index bookkeeping around it.
 """
 
 import logging
@@ -11,7 +10,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from alphadia_search_rs import FragmentCompetition as _RustFragmentCompetition
+from alphadia_search_rs import FragmentCompetition
 from pandas.errors import SettingWithCopyWarning
 
 from alphadia.constants.keys import CalibCols
@@ -19,118 +18,72 @@ from alphadia.fragcomp.utils import add_frag_start_stop_idx, candidate_hash
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_RT_TOLERANCE_SECONDS = 3.0
+DEFAULT_MASS_TOLERANCE_PPM = 15.0
 
-class FragmentCompetition:
-    """Fragment competition class to remove PSMs that share fragments with other PSMs."""
 
-    def __init__(self, rt_tol_seconds: float = 3, mass_tol_ppm: float = 15):
-        """Remove PSMs that share fragments with other PSMs.
+def compete_for_fragments(
+    psm_df: pd.DataFrame,
+    frag_df: pd.DataFrame,
+    cycle: np.ndarray,
+    rt_tol_seconds: float = DEFAULT_RT_TOLERANCE_SECONDS,
+    mass_tol_ppm: float = DEFAULT_MASS_TOLERANCE_PPM,
+) -> pd.DataFrame:
+    """Remove PSMs that share fragments with other PSMs.
 
-        Parameters
-        ----------
-        rt_tol_seconds: float
-            The retention time tolerance in seconds.
+    PSMs compete only against others in the same DIA isolation window and within
+    `rt_tol_seconds`; of two PSMs sharing fragments the one with the lower `proba`
+    wins. Row order is irrelevant and is preserved in the result.
 
-        mass_tol_ppm: float
-            The mass tolerance in ppm.
+    Parameters
+    ----------
+    psm_df: pd.DataFrame
+        The PSM dataframe.
 
-        """
-        self.rt_tol_seconds = rt_tol_seconds
-        self.mass_tol_ppm = mass_tol_ppm
-        self._fragment_competition = _RustFragmentCompetition(
-            float(rt_tol_seconds), float(mass_tol_ppm)
-        )
+    frag_df: pd.DataFrame
+        The fragment dataframe.
 
-    @staticmethod
-    def _add_window_idx(psm_df: pd.DataFrame, cycle: np.ndarray) -> pd.DataFrame:
-        """Add the window index to the PSM dataframe.
+    cycle: np.ndarray
+        DIA cycle.
 
-        Parameters
-        ----------
-        psm_df: pd.DataFrame
-            The PSM dataframe.
+    rt_tol_seconds: float
+        The retention time tolerance in seconds.
 
-        cycle: np.ndarray
-            The cycle array.
+    mass_tol_ppm: float
+        The mass tolerance in ppm.
 
-        Returns
-        -------
-        pd.DataFrame
-            The PSM dataframe with the window index.
+    Returns
+    -------
+    pd.DataFrame
+        The PSM dataframe, reduced to the PSMs that won their fragments.
 
-        """
-        if "window_idx" in psm_df.columns:
-            logger.warning("Window index already present in PSM dataframe. Skipping.")
-            return psm_df
+    """
+    # TODO: this method raises SettingWithCopyWarning. Resolve without increasing memory usage.
 
-        lower_limit = np.min(cycle[0, :, :, 0], axis=1, keepdims=True).T
-        upper_limit = np.max(cycle[0, :, :, 1], axis=1, keepdims=True).T
+    warnings.simplefilter(action="ignore", category=(SettingWithCopyWarning))
 
-        idx = (
-            np.expand_dims(psm_df[CalibCols.MZ_OBSERVED].values, axis=-1) >= lower_limit
-        ) & (
-            np.expand_dims(psm_df[CalibCols.MZ_OBSERVED].values, axis=-1) < upper_limit
-        )
+    psm_df["_candidate_idx"] = candidate_hash(
+        psm_df["precursor_idx"].values, psm_df["rank"].values
+    )
+    frag_df["_candidate_idx"] = candidate_hash(
+        frag_df["precursor_idx"].values, frag_df["rank"].values
+    )
 
-        psm_df["window_idx"] = np.argmax(idx, axis=1)
-        return psm_df
+    psm_df = add_frag_start_stop_idx(psm_df, frag_df)
 
-    def __call__(
-        self, psm_df: pd.DataFrame, frag_df: pd.DataFrame, cycle: np.ndarray
-    ) -> pd.DataFrame:
-        """Remove PSMs that share fragments with other PSMs.
+    valid = FragmentCompetition(rt_tol_seconds, mass_tol_ppm).compete(
+        psm_df[CalibCols.MZ_OBSERVED].to_numpy(dtype=np.float32),
+        psm_df["precursor_idx"].to_numpy(dtype=np.int64),
+        psm_df["proba"].to_numpy(dtype=np.float64),
+        psm_df[CalibCols.RT_OBSERVED].to_numpy(dtype=np.float32),
+        psm_df["_frag_start_idx"].to_numpy(dtype=np.int64),
+        psm_df["_frag_stop_idx"].to_numpy(dtype=np.int64),
+        frag_df[CalibCols.MZ_OBSERVED].to_numpy(dtype=np.float32),
+        np.ascontiguousarray(cycle, dtype=np.float32),
+    )
 
-        Parameters
-        ----------
-        psm_df: pd.DataFrame
-            The PSM dataframe.
+    # clean up
+    psm_df.drop(columns=["_frag_start_idx", "_frag_stop_idx"], inplace=True)
 
-        frag_df: pd.DataFrame
-            The fragment dataframe.
-
-        cycle: np.ndarray
-            DIA cycle.
-
-        Returns
-        -------
-        pd.DataFrame
-            The PSM dataframe with the valid column.
-
-        """
-        # TODO: this method raises SettingWithCopyWarning. Resolve without increasing memory usage.
-
-        warnings.simplefilter(action="ignore", category=(SettingWithCopyWarning))
-
-        psm_df["_candidate_idx"] = candidate_hash(
-            psm_df["precursor_idx"].values, psm_df["rank"].values
-        )
-        frag_df["_candidate_idx"] = candidate_hash(
-            frag_df["precursor_idx"].values, frag_df["rank"].values
-        )
-
-        psm_df = add_frag_start_stop_idx(psm_df, frag_df)
-        psm_df = self._add_window_idx(psm_df, cycle)
-
-        # important to sort by window_idx and proba: the Rust sweep processes
-        # candidates in this order, and within a conflicting pair the earlier one wins
-        psm_df.sort_values(
-            by=["window_idx", "proba", "precursor_idx"], inplace=True
-        )  # last sort to break ties
-
-        valid = self._fragment_competition.compete(
-            psm_df["window_idx"].to_numpy(dtype=np.int64),
-            psm_df[CalibCols.RT_OBSERVED].to_numpy(dtype=np.float32),
-            psm_df["_frag_start_idx"].to_numpy(dtype=np.int64),
-            psm_df["_frag_stop_idx"].to_numpy(dtype=np.int64),
-            frag_df[CalibCols.MZ_OBSERVED].to_numpy(dtype=np.float32),
-        )
-
-        psm_df["valid"] = valid
-
-        # clean up
-        psm_df.drop(
-            columns=["_frag_start_idx", "_frag_stop_idx", "window_idx"], inplace=True
-        )
-
-        warnings.simplefilter(action="default", category=(SettingWithCopyWarning))
-        return psm_df[psm_df["valid"]]
+    warnings.simplefilter(action="default", category=(SettingWithCopyWarning))
+    return psm_df[valid]

--- a/alphadia/fragcomp/fragcomp.py
+++ b/alphadia/fragcomp/fragcomp.py
@@ -1,8 +1,7 @@
 """The fragment competition module contains functionality to maintain the exclusive assignment of signal to identifications.
 
-The numeric work — DIA-window assignment, priority ranking and the fragment-overlap
-sweep — lives in Rust (`alphadia_search_rs.FragmentCompetition`). This module only
-prepares the candidate/fragment index bookkeeping around it.
+The sweep itself lives in Rust (`alphadia_search_rs.FragmentCompetition`); what is
+left here is the dataframe bookkeeping it needs.
 """
 
 import logging
@@ -31,9 +30,9 @@ def compete_for_fragments(
 ) -> pd.DataFrame:
     """Remove PSMs that share fragments with other PSMs.
 
-    PSMs compete only against others in the same DIA isolation window and within
-    `rt_tol_seconds`; of two PSMs sharing fragments the one with the lower `proba`
-    wins. Row order is irrelevant and is preserved in the result.
+    PSMs only compete against others in the same DIA window and within
+    `rt_tol_seconds`, and the lower `proba` wins. Row order does not matter and is
+    preserved.
 
     Parameters
     ----------
@@ -82,7 +81,7 @@ def compete_for_fragments(
         np.ascontiguousarray(cycle, dtype=np.float32),
     )
 
-    # clean up
+    # these only exist to point the Rust sweep at each PSM's fragments
     psm_df.drop(columns=["_frag_start_idx", "_frag_stop_idx"], inplace=True)
 
     warnings.simplefilter(action="default", category=(SettingWithCopyWarning))

--- a/alphadia/fragcomp/fragcomp.py
+++ b/alphadia/fragcomp/fragcomp.py
@@ -1,172 +1,45 @@
-"""The fragment competition module contains functionality to maintain the exclusive assignment of signal to identifications."""
+"""The fragment competition module contains functionality to maintain the exclusive assignment of signal to identifications.
+
+Thin Python wrapper around the Rust fragment-competition kernel
+(`alphadia_search_rs.FragmentCompetition`). The numeric sweep (per-DIA-window
+fragment-overlap comparison) lives in Rust; this wrapper only prepares the
+candidate/fragment index bookkeeping and dataframe I/O.
+"""
 
 import logging
 import warnings
 
-import numba as nb
 import numpy as np
 import pandas as pd
-from alpharaw.utils.pjit import pjit
-from alpharaw.utils.pjit import set_threads as set_pjit_threads
+from alphadia_search_rs import FragmentCompetition as _RustFragmentCompetition
 from pandas.errors import SettingWithCopyWarning
 
 from alphadia.constants.keys import CalibCols
 from alphadia.fragcomp.utils import add_frag_start_stop_idx, candidate_hash
-from alphadia.utils import USE_NUMBA_CACHING
 
 logger = logging.getLogger(__name__)
-
-
-@nb.njit(cache=USE_NUMBA_CACHING)
-def _get_fragment_overlap(
-    frag_mz_1: np.ndarray,
-    frag_mz_2: np.ndarray,
-    mass_tol_ppm: float = 10,
-) -> int:
-    """Get the number of overlapping fragments between two spectra.
-
-    Parameters
-    ----------
-    frag_mz_1: np.ndarray
-        The m/z values of the first spectrum.
-
-    frag_mz_2: np.ndarray
-        The m/z values of the second spectrum.
-
-    mass_tol_ppm: float
-        The mass tolerance in ppm.
-
-    Returns
-    -------
-    int
-        The number of overlapping fragments.
-
-    """
-    frag_mz_1 = frag_mz_1.reshape(-1, 1)
-    frag_mz_2 = frag_mz_2.reshape(1, -1)
-    delta_mz = np.abs(frag_mz_1 - frag_mz_2)
-    ppm_delta_mz = delta_mz / frag_mz_1 * 1e6
-    return np.sum(ppm_delta_mz < mass_tol_ppm)
-
-
-@pjit(cache=USE_NUMBA_CACHING)
-def _compete_for_fragments(  # noqa: PLR0913 # Too many arguments
-    thread_idx: int,  # pjit decorator changes the passed argument from an iterable to single index
-    precursor_start_idxs: np.ndarray,
-    precursor_stop_idxs: np.ndarray,
-    rt: np.ndarray,
-    frag_start_idx: np.ndarray,
-    frag_stop_idx: np.ndarray,
-    fragment_mz: np.ndarray,
-    rt_tol_seconds: float,
-    mass_tol_ppm: float,
-    valid: np.ndarray,
-) -> None:
-    """Remove PSMs that share fragments with other PSMs.
-
-    The function is applied on a dia window basis.
-
-    The pjit decorator thread-parallelizes over the first argument index and additionally wraps with numba.njit(nogil=True).
-    Make sure to read and understand the pjit decorator, especially how it changes the type of the first argument.
-
-    Parameters
-    ----------
-    thread_idx: int
-        The thread index. Each thread will handle one dia window.
-        The pjit decorator effectively changes the type of this argument to `np.ndarray` and thread-parallelizes
-        over it.
-
-    precursor_start_idxs: np.ndarray
-        Array of length n_windows. The start indices of the precursors in the PSM dataframe.
-
-    precursor_stop_idxs: np.ndarray
-        Array of length n_windows. The stop indices of the precursors in the PSM dataframe.
-
-    rt: np.ndarray
-        The retention times of the precursors.
-
-    frag_start_idx: np.ndarray
-        Array of length n_psms. The start indices of the fragments in the fragment dataframe.
-
-    frag_stop_idx: np.ndarray
-        Array of length n_psms. The stop indices of the fragments in the fragment dataframe.
-
-    fragment_mz: np.ndarray
-        The m/z values of the fragments.
-
-    rt_tol_seconds: float
-        The retention time tolerance in seconds.
-
-    mass_tol_ppm: float
-        The mass tolerance in ppm.
-
-    valid: np.ndarray
-        Array of length n_psms. The validity of each PSM. This is where the method output will be stored.
-
-    Returns
-    -------
-        None, but modifies the `valid` array in place.
-
-    """
-    precursor_start_idx = precursor_start_idxs[thread_idx]
-    precursor_stop_idx = precursor_stop_idxs[thread_idx]
-
-    rt_window = rt[precursor_start_idx:precursor_stop_idx]
-    valid_window = valid[precursor_start_idx:precursor_stop_idx]
-
-    for i, i_rt in enumerate(rt_window):
-        if not valid_window[i]:
-            continue
-        for j, j_rt in enumerate(rt_window):
-            if i == j:
-                continue
-            if not valid_window[j]:
-                continue
-
-            delta_rt = abs(i_rt - j_rt)
-            if delta_rt < rt_tol_seconds:
-                fragment_overlap = _get_fragment_overlap(
-                    fragment_mz[
-                        frag_start_idx[precursor_start_idx + i] : frag_stop_idx[
-                            precursor_start_idx + i
-                        ]
-                    ],
-                    fragment_mz[
-                        frag_start_idx[precursor_start_idx + j] : frag_stop_idx[
-                            precursor_start_idx + j
-                        ]
-                    ],
-                    mass_tol_ppm=mass_tol_ppm,
-                )
-                if fragment_overlap >= 3:  # noqa: PLR2004
-                    valid_window[j] = False
-
-    valid[precursor_start_idx:precursor_stop_idx] = valid_window
 
 
 class FragmentCompetition:
     """Fragment competition class to remove PSMs that share fragments with other PSMs."""
 
-    def __init__(
-        self, rt_tol_seconds: int = 3, mass_tol_ppm: int = 15, thread_count: int = 8
-    ):
+    def __init__(self, rt_tol_seconds: float = 3, mass_tol_ppm: float = 15):
         """Remove PSMs that share fragments with other PSMs.
 
         Parameters
         ----------
-        rt_tol_seconds: int
+        rt_tol_seconds: float
             The retention time tolerance in seconds.
 
-        mass_tol_ppm: int
+        mass_tol_ppm: float
             The mass tolerance in ppm.
-
-        thread_count: int
-            The number of threads to use.
 
         """
         self.rt_tol_seconds = rt_tol_seconds
         self.mass_tol_ppm = mass_tol_ppm
-        self.thread_count = thread_count
+        self._fragment_competition = _RustFragmentCompetition(
+            float(rt_tol_seconds), float(mass_tol_ppm)
+        )
 
     @staticmethod
     def _add_window_idx(psm_df: pd.DataFrame, cycle: np.ndarray) -> pd.DataFrame:
@@ -201,33 +74,6 @@ class FragmentCompetition:
 
         psm_df["window_idx"] = np.argmax(idx, axis=1)
         return psm_df
-
-    @staticmethod
-    def _get_thread_plan_df(psm_df: pd.DataFrame) -> pd.DataFrame:
-        """Expects a dataframe sorted by window idxs and qvals.
-
-        Returns a dataframe with start and stop indices of the threads.
-
-        Parameters
-        ----------
-        psm_df: pd.DataFrame
-            The PSM dataframe.
-
-        Returns
-        -------
-        pd.DataFrame
-            The thread plan dataframe.
-
-        """
-        psm_df["_thread_idx"] = np.arange(len(psm_df))
-        index_df = psm_df.groupby("window_idx", as_index=False).agg(
-            start_idx=pd.NamedAgg("_thread_idx", "min"),
-            stop_idx=pd.NamedAgg("_thread_idx", "max"),
-        )
-        index_df["stop_idx"] += 1
-
-        psm_df.drop(columns=["_thread_idx"], inplace=True)
-        return index_df
 
     def __call__(
         self, psm_df: pd.DataFrame, frag_df: pd.DataFrame, cycle: np.ndarray
@@ -265,28 +111,18 @@ class FragmentCompetition:
         psm_df = add_frag_start_stop_idx(psm_df, frag_df)
         psm_df = self._add_window_idx(psm_df, cycle)
 
-        # important to sort by window_idx and proba
+        # important to sort by window_idx and proba: the Rust sweep processes
+        # candidates in this order, and within a conflicting pair the earlier one wins
         psm_df.sort_values(
             by=["window_idx", "proba", "precursor_idx"], inplace=True
         )  # last sort to break ties
 
-        valid = np.ones(len(psm_df)).astype(bool)
-        # psm_df["valid"] = True
-
-        set_pjit_threads(self.thread_count)
-        thread_plan_df = self._get_thread_plan_df(psm_df)
-
-        _compete_for_fragments(
-            np.arange(len(thread_plan_df)),  # type: ignore  # noqa: PGH003  # function is wrapped by pjit -> will be turned into single index and passed to the method
-            thread_plan_df["start_idx"].values,
-            thread_plan_df["stop_idx"].values,
-            psm_df[CalibCols.RT_OBSERVED].values,
-            psm_df["_frag_start_idx"].values,
-            psm_df["_frag_stop_idx"].values,
-            frag_df[CalibCols.MZ_OBSERVED].values,
-            self.rt_tol_seconds,
-            self.mass_tol_ppm,
-            valid,
+        valid = self._fragment_competition.compete(
+            psm_df["window_idx"].to_numpy(dtype=np.int64),
+            psm_df[CalibCols.RT_OBSERVED].to_numpy(dtype=np.float32),
+            psm_df["_frag_start_idx"].to_numpy(dtype=np.int64),
+            psm_df["_frag_stop_idx"].to_numpy(dtype=np.int64),
+            frag_df[CalibCols.MZ_OBSERVED].to_numpy(dtype=np.float32),
         )
 
         psm_df["valid"] = valid

--- a/tests/unit_tests/fragcomp/test_fragcomp.py
+++ b/tests/unit_tests/fragcomp/test_fragcomp.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from alphadia.fragcomp.fragcomp import FragmentCompetition
+from alphadia.fragcomp.fragcomp import compete_for_fragments
 from alphadia.fragcomp.utils import candidate_hash
 
 
@@ -12,7 +12,6 @@ def test_fragment_competition():
         {
             "precursor_idx": np.arange(6, dtype=np.uint32),
             "rt_observed": np.array([10.0, 20.0, 20.0, 10.0, 10.0, 20]),
-            "valid": np.array([True] * 6),
             "mz_observed": np.array([100, 100, 100, 200, 200, 200]),
             "proba": np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
             "rank": np.zeros(6, dtype=np.uint8),
@@ -28,8 +27,7 @@ def test_fragment_competition():
     )
 
     # when
-    fragment_competition = FragmentCompetition()
-    psm_df = fragment_competition(psm_df, frag_df, cycle)
+    psm_df = compete_for_fragments(psm_df, frag_df, cycle)
 
     pd.testing.assert_frame_equal(
         psm_df.reset_index(drop=True),
@@ -37,7 +35,6 @@ def test_fragment_competition():
             {
                 "precursor_idx": np.array([0, 1, 3, 5], dtype=np.uint32),
                 "rt_observed": np.array([10.0, 20.0, 10.0, 20]),
-                "valid": np.array([True] * 4),
                 "mz_observed": np.array([100, 100, 200, 200]),
                 "proba": np.array([0.1, 0.2, 0.4, 0.6]),
                 "rank": np.array([0, 0, 0, 0], dtype=np.uint8),

--- a/tests/unit_tests/fragcomp/test_fragcomp.py
+++ b/tests/unit_tests/fragcomp/test_fragcomp.py
@@ -1,61 +1,8 @@
 import numpy as np
 import pandas as pd
 
-from alphadia.fragcomp.fragcomp import (
-    FragmentCompetition,
-    _compete_for_fragments,
-    _get_fragment_overlap,
-)
+from alphadia.fragcomp.fragcomp import FragmentCompetition
 from alphadia.fragcomp.utils import candidate_hash
-
-
-def test_fragment_overlap():
-    frag_mz_1 = np.array([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000])
-    frag_mz_2 = np.array([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000])
-    assert _get_fragment_overlap(frag_mz_1, frag_mz_2) == 10
-
-    frag_mz_1 = np.array([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000])
-    frag_mz_2 = np.array([100])
-    assert _get_fragment_overlap(frag_mz_1, frag_mz_2) == 1
-
-    frag_mz_1 = np.array([])
-    frag_mz_2 = np.array([])
-    assert _get_fragment_overlap(frag_mz_1, frag_mz_2) == 0
-
-    frag_mz_1 = np.array([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000])
-    frag_mz_2 = np.array([])
-    assert _get_fragment_overlap(frag_mz_1, frag_mz_2) == 0
-
-    frag_mz_1 = np.array([])
-    frag_mz_2 = np.array([100, 200, 300, 400, 500, 600, 700, 801, 901, 1001])
-    assert _get_fragment_overlap(frag_mz_1, frag_mz_2) == 0
-
-    frag_mz_1 = np.array([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000])
-    frag_mz_2 = np.array([101, 201, 301, 401, 501, 601, 701, 801, 901, 1001])
-    assert _get_fragment_overlap(frag_mz_1, frag_mz_2) == 0
-
-
-def test_compete_for_fragments():
-    rt = np.array([10.0, 20.0, 20.0, 10.0, 10.0, 20])
-    valid = np.array([True] * 6)
-    frag_start_idx = np.array([0, 10, 20, 30, 40, 50])
-    frag_stop_idx = np.array([10, 20, 30, 40, 50, 60])
-    fragment_mz = np.tile(np.arange(100, 110), 6)
-
-    _compete_for_fragments(
-        np.array([0, 1]),
-        np.array([0, 3]),
-        np.array([3, 6]),
-        rt,
-        frag_start_idx,
-        frag_stop_idx,
-        fragment_mz,
-        3,
-        15,
-        valid,
-    )
-
-    assert np.all(valid == np.array([True, True, False, True, False, True]))
 
 
 def test_fragment_competition():


### PR DESCRIPTION
Replaces the numba/pjit `FragmentCompetition` sweep with a thin wrapper around `alphadia_search_rs.FragmentCompetition`. Drops the now-unused `thread_count` param (Rust uses the crate's global rayon pool).

Depends on MannLabs/alphadia-search-rs#132 — not mergeable until that's released and the requirements pin is bumped.

Test plan:
- [x] `tests/unit_tests/fragcomp`, `tests/unit_tests/fdr` pass locally against a `maturin develop` build of #132
- [ ] full suite once #132 is released and the pin is bumped