### PR TITLE
Fix ZeroDivisionError when an optimization batch extracts nothing

### DIFF
--- a/alphadia/workflow/optimizers/automatic.py
+++ b/alphadia/workflow/optimizers/automatic.py
@@ -42,14 +42,6 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         See base class for other parameters.
 
         """
-        # Fail here rather than minutes into the first search: without the abstract
-        # _get_feature_value, a subclass that forgets to declare its feature would
-        # otherwise raise deep inside the first optimization round.
-        if not hasattr(self, "_feature"):
-            raise NotImplementedError(
-                f"{type(self).__name__} must declare a class-level _feature."
-            )
-
         super().__init__(
             config, optimization_manager, calibration_manager, fdr_manager, reporter
         )
@@ -114,9 +106,9 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         )
 
         if not self._update_history(precursors_df, fragments_df):
-            # Without a measurement there is nothing to converge on, and the empty frame
-            # would calibrate the next parameter to zero or NaN, making every later
-            # search extract nothing. Leave the parameter as it is.
+            # Without a measurement there is no value to converge on. Also, an empty
+            # frame calibrates the next parameter to zero or NaN. Then all subsequent
+            # searches find nothing. Thus keep the parameter at its current value.
             return
 
         if self._just_converged:
@@ -162,7 +154,7 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         """Plot the value of the feature used to assess optimization progress against the parameter value, for each value tested."""
         if self.history_df.empty:
             self._reporter.log_string(
-                f"{self.parameter_name}: no measurement recorded, nothing to plot.",
+                f"{self.parameter_name}: there is no measurement to plot.",
                 verbosity="warning",
             )
             return
@@ -231,20 +223,22 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         Returns
         -------
         bool
-            True if a measurement was recorded, False if this round admitted none.
+            True if this method recorded a measurement, False if it did not.
 
         """
         feature_value = self._feature.measure(
             precursors_df, fragments_df, self._optlock
         )
 
-        # A round without a measurement is not a measurement of zero: a sentinel value
-        # here would make the relative comparisons in _just_converged and the axis
-        # limits in plot() non-finite instead of raising.
+        # A round with no measurement is different from a measurement of zero. A
+        # substitute value of zero makes the relative calculations in _just_converged
+        # and the axis limits in plot() infinite or NaN. The code does not raise an
+        # error and the fault stays hidden.
         if feature_value is None:
             self._reporter.log_string(
-                f"{self.parameter_name}: {self._feature.name} is undefined for batch "
-                f"{self._optlock.batch_idx}; no measurement recorded for this round.",
+                f"{self.parameter_name}: {self._feature.name} has no definition for "
+                f"batch {self._optlock.batch_idx}. No measurement was recorded for "
+                f"this round.",
                 verbosity="warning",
             )
             return False
@@ -406,7 +400,7 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         """
         if self.history_df.empty:
             self._reporter.log_string(
-                f"{self.parameter_name}: no round produced a measurement; keeping the current value.",
+                f"{self.parameter_name}: no round gave a measurement. The current value stays.",
                 verbosity="warning",
             )
             return

--- a/alphadia/workflow/optimizers/automatic.py
+++ b/alphadia/workflow/optimizers/automatic.py
@@ -42,6 +42,14 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         See base class for other parameters.
 
         """
+        # Fail here rather than minutes into the first search: without the abstract
+        # _get_feature_value, a subclass that forgets to declare its feature would
+        # otherwise raise deep inside the first optimization round.
+        if not hasattr(self, "_feature"):
+            raise NotImplementedError(
+                f"{type(self).__name__} must declare a class-level _feature."
+            )
+
         super().__init__(
             config, optimization_manager, calibration_manager, fdr_manager, reporter
         )
@@ -105,7 +113,11 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
             verbosity="progress",
         )
 
-        self._update_history(precursors_df, fragments_df)
+        if not self._update_history(precursors_df, fragments_df):
+            # Without a measurement there is nothing to converge on, and the empty frame
+            # would calibrate the next parameter to zero or NaN, making every later
+            # search extract nothing. Leave the parameter as it is.
+            return
 
         if self._just_converged:
             self.has_converged = True
@@ -148,6 +160,13 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
 
     def plot(self):
         """Plot the value of the feature used to assess optimization progress against the parameter value, for each value tested."""
+        if self.history_df.empty:
+            self._reporter.log_string(
+                f"{self.parameter_name}: no measurement recorded, nothing to plot.",
+                verbosity="warning",
+            )
+            return
+
         fig, ax = plt.subplots()
 
         ax.vlines(
@@ -204,16 +223,15 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
             ).ci(df, self.update_percentile_range)
         )
 
-    def _update_history(self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame):
-        """This method updates the history dataframe with relevant values.
+    def _update_history(
+        self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame
+    ) -> bool:
+        """See base class.
 
-        Parameters
-        ----------
-        precursors_df: pd.DataFrame
-            The filtered precursor dataframe for the search.
-
-        fragments_df: pd.DataFrame
-            The filtered fragment dataframe for the search.
+        Returns
+        -------
+        bool
+            True if a measurement was recorded, False if this round admitted none.
 
         """
         feature_value = self._feature.measure(
@@ -225,11 +243,11 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         # limits in plot() non-finite instead of raising.
         if feature_value is None:
             self._reporter.log_string(
-                f"{self.parameter_name}: batch {self._optlock.batch_idx} extracted nothing; "
-                f"no {self._feature.name} recorded for this round.",
+                f"{self.parameter_name}: {self._feature.name} is undefined for batch "
+                f"{self._optlock.batch_idx}; no measurement recorded for this round.",
                 verbosity="warning",
             )
-            return
+            return False
 
         new_row = pd.DataFrame(
             [
@@ -247,6 +265,7 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
             ]
         )
         self.history_df = pd.concat([self.history_df, new_row], ignore_index=True)
+        return True
 
     @property
     def _batch_substantially_bigger(self):

--- a/alphadia/workflow/optimizers/automatic.py
+++ b/alphadia/workflow/optimizers/automatic.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -14,6 +14,10 @@ from alphadia.workflow.managers.calibration_manager import (
 from alphadia.workflow.managers.fdr_manager import FDRManager
 from alphadia.workflow.managers.optimization_manager import OptimizationManager
 from alphadia.workflow.optimizers.base import BaseOptimizer
+from alphadia.workflow.optimizers.features import (
+    MeanIsotopeIntensityCorrelation,
+    PrecursorProportionDetected,
+)
 from alphadia.workflow.optimizers.optimization_lock import OptimizationLock
 
 
@@ -149,7 +153,7 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         ax.vlines(
             x=self._optimization_manager.__dict__[self.parameter_name],
             ymin=0,
-            ymax=self.history_df.loc[self._find_index_of_optimum(), self._feature_name],
+            ymax=self.history_df.loc[self._find_index_of_optimum(), self._feature.name],
             color="red",
             zorder=0,
             label=f"Optimal {self.parameter_name}",
@@ -159,16 +163,16 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         sorted_history_df = self.history_df.sort_values("parameter")
         ax.plot(
             sorted_history_df["parameter"],
-            sorted_history_df[self._feature_name],
+            sorted_history_df[self._feature.name],
         )
         ax.scatter(
             self.history_df["parameter"],
-            self.history_df[self._feature_name],
+            self.history_df[self._feature.name],
         )
 
         ax.set_xlabel(self.parameter_name)
         ax.xaxis.set_inverted(True)
-        ax.set_ylim(bottom=0, top=self.history_df[self._feature_name].max() * 1.1)
+        ax.set_ylim(bottom=0, top=self.history_df[self._feature.name].max() * 1.1)
         ax.legend(loc="upper left")
 
         plt.show()
@@ -212,15 +216,28 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
             The filtered fragment dataframe for the search.
 
         """
+        feature_value = self._feature.measure(
+            precursors_df, fragments_df, self._optlock
+        )
+
+        # A round without a measurement is not a measurement of zero: a sentinel value
+        # here would make the relative comparisons in _just_converged and the axis
+        # limits in plot() non-finite instead of raising.
+        if feature_value is None:
+            self._reporter.log_string(
+                f"{self.parameter_name}: batch {self._optlock.batch_idx} extracted nothing; "
+                f"no {self._feature.name} recorded for this round.",
+                verbosity="warning",
+            )
+            return
+
         new_row = pd.DataFrame(
             [
                 {
                     "parameter": self._optimization_manager.__dict__[
                         self.parameter_name
                     ],
-                    self._feature_name: self._get_feature_value(
-                        precursors_df, fragments_df
-                    ),
+                    self._feature.name: feature_value,
                     "classifier_version": self._fdr_manager.current_version,  # TODO: only we need from fdr_manager
                     "score_cutoff": self._optimization_manager.score_cutoff,
                     "fwhm_rt": self._optimization_manager.fwhm_rt,
@@ -269,7 +286,7 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         if len(self.history_df) < 3:
             return False
 
-        feature_history = self.history_df[self._feature_name]
+        feature_history = self.history_df[self._feature.name]
         last_feature_value = feature_history.iloc[-1]
         second_last_feature_value = feature_history.iloc[-2]
         third_last_feature_value = feature_history.iloc[-3]
@@ -339,24 +356,24 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
             return self.history_df.index[0]
 
         if self._favour_narrower_optimum:  # This setting can be useful for optimizing parameters for which many parameter values have similar feature values.
-            maximum_feature_value = self.history_df[self._feature_name].max()
+            maximum_feature_value = self.history_df[self._feature.name].max()
             threshold = (
                 maximum_feature_value
                 - self._maximum_decrease_from_maximum * np.abs(maximum_feature_value)
             )
 
             rows_within_thresh_of_max = self.history_df[
-                self.history_df[self._feature_name] > threshold
+                self.history_df[self._feature.name] > threshold
             ]
 
             if rows_within_thresh_of_max.empty:
                 # If no rows meet the threshold, return the index of the max feature value
-                return self.history_df[self._feature_name].idxmax()
+                return self.history_df[self._feature.name].idxmax()
             else:
                 return rows_within_thresh_of_max["parameter"].idxmin()
 
         else:
-            return self.history_df[self._feature_name].idxmax()
+            return self.history_df[self._feature.name].idxmax()
 
     def _update_workflow(self):
         """Updates the optimization manager with the results of the optimization, namely:
@@ -368,6 +385,13 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         at the optimal parameter. Also updates the optlock with the batch index at the optimum.
 
         """
+        if self.history_df.empty:
+            self._reporter.log_string(
+                f"{self.parameter_name}: no round produced a measurement; keeping the current value.",
+                verbosity="warning",
+            )
+            return
+
         index_of_optimum = self._find_index_of_optimum()
 
         optimal_parameter = self.history_df["parameter"].loc[index_of_optimum]
@@ -396,26 +420,10 @@ class AutomaticOptimizer(BaseOptimizer, ABC):
         # The time impact of this is negligible and the benefits can be significant.
         self._optlock.batch_idx = batch_index_at_optimum
 
-    @abstractmethod
-    def _get_feature_value(
-        self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame
-    ):
-        """Each parameter is optimized according to a particular feature. This method gets the value of that feature for a given round of optimization.
-
-        Parameters
-        ----------
-
-        precursors_df: pd.DataFrame
-            The precursor dataframe for the search
-
-        fragments_df: pd.DataFrame
-            The fragment dataframe for the search
-
-
-        """
-
 
 class AutomaticRTOptimizer(AutomaticOptimizer):
+    _feature = PrecursorProportionDetected()
+
     def __init__(
         self,
         initial_parameter: float,
@@ -430,7 +438,6 @@ class AutomaticRTOptimizer(AutomaticOptimizer):
         self.parameter_name = "rt_error"
         self._estimator_group_name = CalibrationGroups.PRECURSOR
         self._estimator_name = CalibrationEstimators.RT
-        self._feature_name = "precursor_proportion_detected"
         super().__init__(
             initial_parameter,
             config,
@@ -441,13 +448,10 @@ class AutomaticRTOptimizer(AutomaticOptimizer):
             reporter,
         )
 
-    def _get_feature_value(
-        self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame
-    ):
-        return len(precursors_df) / self._optlock.total_elution_groups
-
 
 class AutomaticMS2Optimizer(AutomaticOptimizer):
+    _feature = PrecursorProportionDetected()
+
     def __init__(
         self,
         initial_parameter: float,
@@ -462,7 +466,6 @@ class AutomaticMS2Optimizer(AutomaticOptimizer):
         self.parameter_name = "ms2_error"
         self._estimator_group_name = CalibrationGroups.FRAGMENT
         self._estimator_name = CalibrationEstimators.MZ
-        self._feature_name = "precursor_proportion_detected"
         super().__init__(
             initial_parameter,
             config,
@@ -473,13 +476,10 @@ class AutomaticMS2Optimizer(AutomaticOptimizer):
             reporter,
         )
 
-    def _get_feature_value(
-        self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame
-    ):
-        return len(precursors_df) / self._optlock.total_elution_groups
-
 
 class AutomaticMS1Optimizer(AutomaticOptimizer):
+    _feature = MeanIsotopeIntensityCorrelation()
+
     def __init__(
         self,
         initial_parameter: float,
@@ -494,7 +494,6 @@ class AutomaticMS1Optimizer(AutomaticOptimizer):
         self.parameter_name = "ms1_error"
         self._estimator_group_name = CalibrationGroups.PRECURSOR
         self._estimator_name = CalibrationEstimators.MZ
-        self._feature_name = "mean_isotope_intensity_correlation"
         super().__init__(
             initial_parameter,
             config,
@@ -505,13 +504,10 @@ class AutomaticMS1Optimizer(AutomaticOptimizer):
             reporter,
         )
 
-    def _get_feature_value(
-        self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame
-    ):
-        return precursors_df["isotope_intensity_correlation"].mean()
-
 
 class AutomaticMobilityOptimizer(AutomaticOptimizer):
+    _feature = PrecursorProportionDetected()
+
     def __init__(
         self,
         initial_parameter: float,
@@ -526,7 +522,6 @@ class AutomaticMobilityOptimizer(AutomaticOptimizer):
         self.parameter_name = "mobility_error"
         self._estimator_group_name = CalibrationGroups.PRECURSOR
         self._estimator_name = CalibrationEstimators.MOBILITY
-        self._feature_name = "precursor_proportion_detected"
         super().__init__(
             initial_parameter,
             config,
@@ -536,8 +531,3 @@ class AutomaticMobilityOptimizer(AutomaticOptimizer):
             optlock,
             reporter,
         )
-
-    def _get_feature_value(
-        self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame
-    ):
-        return len(precursors_df) / self._optlock.total_elution_groups

--- a/alphadia/workflow/optimizers/base.py
+++ b/alphadia/workflow/optimizers/base.py
@@ -93,7 +93,9 @@ class BaseOptimizer(ABC):
         """
 
     @abstractmethod
-    def _update_history(self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame):
+    def _update_history(
+        self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame
+    ) -> bool:
         """This method updates the history dataframe with relevant values.
 
         Parameters
@@ -103,5 +105,10 @@ class BaseOptimizer(ABC):
 
         fragments_df: pd.DataFrame
             The filtered fragment dataframe for the search.
+
+        Returns
+        -------
+        bool
+            True if a measurement was recorded, False otherwise.
 
         """

--- a/alphadia/workflow/optimizers/base.py
+++ b/alphadia/workflow/optimizers/base.py
@@ -109,6 +109,6 @@ class BaseOptimizer(ABC):
         Returns
         -------
         bool
-            True if a measurement was recorded, False otherwise.
+            True if this method recorded a measurement, False if it did not.
 
         """

--- a/alphadia/workflow/optimizers/base.py
+++ b/alphadia/workflow/optimizers/base.py
@@ -7,13 +7,14 @@ from alphadia.workflow.config import Config
 from alphadia.workflow.managers.calibration_manager import CalibrationManager
 from alphadia.workflow.managers.fdr_manager import FDRManager
 from alphadia.workflow.managers.optimization_manager import OptimizationManager
+from alphadia.workflow.optimizers.features import OptimizationFeature
 
 
 class BaseOptimizer(ABC):
     parameter_name: str | None
     _estimator_name: str | None
     _estimator_group_name: str | None
-    _feature_name: str | None
+    _feature: OptimizationFeature
 
     def __init__(
         self,

--- a/alphadia/workflow/optimizers/features.py
+++ b/alphadia/workflow/optimizers/features.py
@@ -82,4 +82,10 @@ class MeanIsotopeIntensityCorrelation(OptimizationFeature):
         """See base class."""
         if precursors_df.empty:
             return None
-        return precursors_df["isotope_intensity_correlation"].mean()
+
+        # An all-NaN column is as unmeasurable as an empty frame, and pandas reports
+        # both as NaN rather than raising.
+        mean_correlation = precursors_df["isotope_intensity_correlation"].mean()
+        if pd.isna(mean_correlation):
+            return None
+        return float(mean_correlation)

--- a/alphadia/workflow/optimizers/features.py
+++ b/alphadia/workflow/optimizers/features.py
@@ -1,4 +1,4 @@
-"""Features tracked by the automatic optimizers across optimization rounds."""
+"""The features that the automatic optimizers track in each optimization round."""
 
 from abc import ABC, abstractmethod
 
@@ -8,13 +8,14 @@ from alphadia.workflow.optimizers.optimization_lock import OptimizationLock
 
 
 class OptimizationFeature(ABC):
-    """The quantity an AutomaticOptimizer maximises across optimization rounds.
+    """The value that an AutomaticOptimizer makes as large as possible.
 
-    Bundles the history column name with its computation so the two cannot drift
-    apart, and gives every feature one definition of the empty search.
+    A feature keeps its history column name and its calculation together. Thus the
+    name and the calculation stay in agreement. Each feature also gives one
+    definition of a round that has no data.
 
-    Implementations must be stateless: a single instance is shared by all
-    optimizers declaring the feature.
+    A feature must not keep state. All optimizers that use a feature share one
+    instance of it.
     """
 
     name: str
@@ -26,7 +27,7 @@ class OptimizationFeature(ABC):
         fragments_df: pd.DataFrame,
         optlock: OptimizationLock,
     ) -> float | None:
-        """Return the feature value, or None when this round admits no measurement.
+        """Calculate the feature value for one optimization round.
 
         Parameters
         ----------
@@ -37,17 +38,22 @@ class OptimizationFeature(ABC):
             The filtered fragment dataframe for the search.
 
         optlock: OptimizationLock
-            The optimization lock holding the state of the current batch.
+            The optimization lock that holds the state of the current batch.
+
+        Returns
+        -------
+        float | None
+            The feature value, or None if this round has no data to measure.
 
         """
 
 
 class PrecursorProportionDetected(OptimizationFeature):
-    """Fraction of the batch's elution groups that yielded a precursor at 1% FDR.
+    """The part of the elution groups in the batch that gave a precursor at 1% FDR.
 
-    Undefined when the batch contributed no elution groups: there is nothing for a
-    proportion to be *of*. Zero precursors out of a non-empty batch, by contrast, is
-    a real measurement of zero and is recorded as such.
+    The value has no definition if the batch has no elution groups. There is no
+    quantity to calculate a part of. But if the batch has elution groups and no
+    precursor, the value is a correct measurement of zero. The optimizer records it.
     """
 
     name = "precursor_proportion_detected"
@@ -65,10 +71,11 @@ class PrecursorProportionDetected(OptimizationFeature):
 
 
 class MeanIsotopeIntensityCorrelation(OptimizationFeature):
-    """Mean isotope intensity correlation over the detected precursors.
+    """The mean isotope intensity correlation of the precursors that were found.
 
-    Undefined with no precursors: pandas returns NaN, which propagates silently
-    through the convergence comparisons rather than stopping them.
+    The value has no definition if there is no precursor. In this condition pandas
+    gives NaN. A NaN does not stop the convergence calculations. It moves through
+    them without a message.
     """
 
     name = "mean_isotope_intensity_correlation"
@@ -83,8 +90,8 @@ class MeanIsotopeIntensityCorrelation(OptimizationFeature):
         if precursors_df.empty:
             return None
 
-        # An all-NaN column is as unmeasurable as an empty frame, and pandas reports
-        # both as NaN rather than raising.
+        # A column that contains only NaN has no more data than an empty frame.
+        # Pandas gives NaN for the two conditions and does not raise an error.
         mean_correlation = precursors_df["isotope_intensity_correlation"].mean()
         if pd.isna(mean_correlation):
             return None

--- a/alphadia/workflow/optimizers/features.py
+++ b/alphadia/workflow/optimizers/features.py
@@ -1,0 +1,85 @@
+"""Features tracked by the automatic optimizers across optimization rounds."""
+
+from abc import ABC, abstractmethod
+
+import pandas as pd
+
+from alphadia.workflow.optimizers.optimization_lock import OptimizationLock
+
+
+class OptimizationFeature(ABC):
+    """The quantity an AutomaticOptimizer maximises across optimization rounds.
+
+    Bundles the history column name with its computation so the two cannot drift
+    apart, and gives every feature one definition of the empty search.
+
+    Implementations must be stateless: a single instance is shared by all
+    optimizers declaring the feature.
+    """
+
+    name: str
+
+    @abstractmethod
+    def measure(
+        self,
+        precursors_df: pd.DataFrame,
+        fragments_df: pd.DataFrame,
+        optlock: OptimizationLock,
+    ) -> float | None:
+        """Return the feature value, or None when this round admits no measurement.
+
+        Parameters
+        ----------
+        precursors_df: pd.DataFrame
+            The filtered precursor dataframe for the search.
+
+        fragments_df: pd.DataFrame
+            The filtered fragment dataframe for the search.
+
+        optlock: OptimizationLock
+            The optimization lock holding the state of the current batch.
+
+        """
+
+
+class PrecursorProportionDetected(OptimizationFeature):
+    """Fraction of the batch's elution groups that yielded a precursor at 1% FDR.
+
+    Undefined when the batch contributed no elution groups: there is nothing for a
+    proportion to be *of*. Zero precursors out of a non-empty batch, by contrast, is
+    a real measurement of zero and is recorded as such.
+    """
+
+    name = "precursor_proportion_detected"
+
+    def measure(
+        self,
+        precursors_df: pd.DataFrame,
+        fragments_df: pd.DataFrame,
+        optlock: OptimizationLock,
+    ) -> float | None:
+        """See base class."""
+        if optlock.total_elution_groups == 0:
+            return None
+        return len(precursors_df) / optlock.total_elution_groups
+
+
+class MeanIsotopeIntensityCorrelation(OptimizationFeature):
+    """Mean isotope intensity correlation over the detected precursors.
+
+    Undefined with no precursors: pandas returns NaN, which propagates silently
+    through the convergence comparisons rather than stopping them.
+    """
+
+    name = "mean_isotope_intensity_correlation"
+
+    def measure(
+        self,
+        precursors_df: pd.DataFrame,
+        fragments_df: pd.DataFrame,
+        optlock: OptimizationLock,
+    ) -> float | None:
+        """See base class."""
+        if precursors_df.empty:
+            return None
+        return precursors_df["isotope_intensity_correlation"].mean()

--- a/alphadia/workflow/optimizers/targeted.py
+++ b/alphadia/workflow/optimizers/targeted.py
@@ -135,7 +135,7 @@ class TargetedOptimizer(BaseOptimizer, ABC):
     def _update_history(
         self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame
     ) -> bool:
-        """See base class. Targeted optimization keeps no history."""
+        """See base class. A targeted optimizer does not keep a history."""
         return False
 
 

--- a/alphadia/workflow/optimizers/targeted.py
+++ b/alphadia/workflow/optimizers/targeted.py
@@ -132,8 +132,11 @@ class TargetedOptimizer(BaseOptimizer, ABC):
     def _update_workflow(self):
         pass
 
-    def _update_history(self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame):
-        pass
+    def _update_history(
+        self, precursors_df: pd.DataFrame, fragments_df: pd.DataFrame
+    ) -> bool:
+        """See base class. Targeted optimization keeps no history."""
+        return False
 
 
 class TargetedRTOptimizer(TargetedOptimizer):

--- a/tests/unit_tests/workflow/optimizers/test_optimization_features.py
+++ b/tests/unit_tests/workflow/optimizers/test_optimization_features.py
@@ -81,6 +81,21 @@ def test_mean_isotope_intensity_correlation_returns_none_for_empty_precursors():
     assert value is None
 
 
+def test_mean_isotope_intensity_correlation_returns_none_for_all_nan_column():
+    """Tests that an all-NaN column yields None rather than a NaN that propagates silently."""
+    # given
+    feature = MeanIsotopeIntensityCorrelation()
+    precursors_df = pd.DataFrame(
+        {"isotope_intensity_correlation": [np.nan, np.nan, np.nan]}
+    )
+
+    # when
+    value = feature.measure(precursors_df, pd.DataFrame(), _optlock(2000))
+
+    # then
+    assert value is None
+
+
 def test_feature_names():
     """Tests that the features keep the history column names used before the refactor."""
     # given / when / then

--- a/tests/unit_tests/workflow/optimizers/test_optimization_features.py
+++ b/tests/unit_tests/workflow/optimizers/test_optimization_features.py
@@ -19,7 +19,7 @@ def _optlock(total_elution_groups: int) -> MagicMock:
 
 
 def test_precursor_proportion_detected_returns_ratio():
-    """Tests that the precursor proportion is the number of precursors over the elution groups."""
+    """Test that the feature divides the number of precursors by the elution groups."""
     # given
     feature = PrecursorProportionDetected()
     precursors_df = pd.DataFrame({"precursor_idx": np.arange(500)})
@@ -32,7 +32,10 @@ def test_precursor_proportion_detected_returns_ratio():
 
 
 def test_precursor_proportion_detected_returns_zero_for_empty_precursors():
-    """Tests that no precursors in a non-empty batch is a measurement of zero, not a missing measurement."""
+    """Test that a batch with elution groups and no precursor measures zero.
+
+    This value is a correct measurement. It is not a missing measurement.
+    """
     # given
     feature = PrecursorProportionDetected()
 
@@ -44,7 +47,7 @@ def test_precursor_proportion_detected_returns_zero_for_empty_precursors():
 
 
 def test_precursor_proportion_detected_returns_none_for_empty_batch():
-    """Tests that a batch without elution groups admits no measurement."""
+    """Test that a batch with no elution group gives no measurement."""
     # given
     feature = PrecursorProportionDetected()
 
@@ -56,7 +59,7 @@ def test_precursor_proportion_detected_returns_none_for_empty_batch():
 
 
 def test_mean_isotope_intensity_correlation_returns_mean():
-    """Tests that the mean isotope intensity correlation is averaged over the precursors."""
+    """Test that the feature calculates the mean over the precursors."""
     # given
     feature = MeanIsotopeIntensityCorrelation()
     precursors_df = pd.DataFrame({"isotope_intensity_correlation": [0.2, 0.4, 0.6]})
@@ -69,7 +72,7 @@ def test_mean_isotope_intensity_correlation_returns_mean():
 
 
 def test_mean_isotope_intensity_correlation_returns_none_for_empty_precursors():
-    """Tests that an empty precursor frame yields None rather than NaN."""
+    """Test that an empty precursor frame gives None and not NaN."""
     # given
     feature = MeanIsotopeIntensityCorrelation()
     precursors_df = pd.DataFrame({"isotope_intensity_correlation": []})
@@ -82,7 +85,10 @@ def test_mean_isotope_intensity_correlation_returns_none_for_empty_precursors():
 
 
 def test_mean_isotope_intensity_correlation_returns_none_for_all_nan_column():
-    """Tests that an all-NaN column yields None rather than a NaN that propagates silently."""
+    """Test that a column with only NaN gives None.
+
+    A NaN moves through the subsequent calculations without a message.
+    """
     # given
     feature = MeanIsotopeIntensityCorrelation()
     precursors_df = pd.DataFrame(
@@ -97,7 +103,7 @@ def test_mean_isotope_intensity_correlation_returns_none_for_all_nan_column():
 
 
 def test_feature_names():
-    """Tests that the features keep the history column names used before the refactor."""
+    """Test that the features keep the history column names of the previous code."""
     # given / when / then
     assert PrecursorProportionDetected.name == "precursor_proportion_detected"
     assert MeanIsotopeIntensityCorrelation.name == "mean_isotope_intensity_correlation"

--- a/tests/unit_tests/workflow/optimizers/test_optimization_features.py
+++ b/tests/unit_tests/workflow/optimizers/test_optimization_features.py
@@ -1,0 +1,88 @@
+"""Unit tests for the optimization features."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from alphadia.workflow.optimizers.features import (
+    MeanIsotopeIntensityCorrelation,
+    PrecursorProportionDetected,
+)
+
+
+def _optlock(total_elution_groups: int) -> MagicMock:
+    optlock = MagicMock()
+    optlock.total_elution_groups = total_elution_groups
+    return optlock
+
+
+def test_precursor_proportion_detected_returns_ratio():
+    """Tests that the precursor proportion is the number of precursors over the elution groups."""
+    # given
+    feature = PrecursorProportionDetected()
+    precursors_df = pd.DataFrame({"precursor_idx": np.arange(500)})
+
+    # when
+    value = feature.measure(precursors_df, pd.DataFrame(), _optlock(2000))
+
+    # then
+    assert value == 500 / 2000
+
+
+def test_precursor_proportion_detected_returns_zero_for_empty_precursors():
+    """Tests that no precursors in a non-empty batch is a measurement of zero, not a missing measurement."""
+    # given
+    feature = PrecursorProportionDetected()
+
+    # when
+    value = feature.measure(pd.DataFrame(), pd.DataFrame(), _optlock(2000))
+
+    # then
+    assert value == 0.0
+
+
+def test_precursor_proportion_detected_returns_none_for_empty_batch():
+    """Tests that a batch without elution groups admits no measurement."""
+    # given
+    feature = PrecursorProportionDetected()
+
+    # when
+    value = feature.measure(pd.DataFrame(), pd.DataFrame(), _optlock(0))
+
+    # then
+    assert value is None
+
+
+def test_mean_isotope_intensity_correlation_returns_mean():
+    """Tests that the mean isotope intensity correlation is averaged over the precursors."""
+    # given
+    feature = MeanIsotopeIntensityCorrelation()
+    precursors_df = pd.DataFrame({"isotope_intensity_correlation": [0.2, 0.4, 0.6]})
+
+    # when
+    value = feature.measure(precursors_df, pd.DataFrame(), _optlock(2000))
+
+    # then
+    assert value == pytest.approx(0.4)
+
+
+def test_mean_isotope_intensity_correlation_returns_none_for_empty_precursors():
+    """Tests that an empty precursor frame yields None rather than NaN."""
+    # given
+    feature = MeanIsotopeIntensityCorrelation()
+    precursors_df = pd.DataFrame({"isotope_intensity_correlation": []})
+
+    # when
+    value = feature.measure(precursors_df, pd.DataFrame(), _optlock(2000))
+
+    # then
+    assert value is None
+
+
+def test_feature_names():
+    """Tests that the features keep the history column names used before the refactor."""
+    # given / when / then
+    assert PrecursorProportionDetected.name == "precursor_proportion_detected"
+    assert MeanIsotopeIntensityCorrelation.name == "mean_isotope_intensity_correlation"

--- a/tests/unit_tests/workflow/test_workflow.py
+++ b/tests/unit_tests/workflow/test_workflow.py
@@ -21,6 +21,7 @@ from alphadia.workflow.optimizers.automatic import (
     AutomaticMobilityOptimizer,
     AutomaticMS1Optimizer,
     AutomaticMS2Optimizer,
+    AutomaticOptimizer,
     AutomaticRTOptimizer,
 )
 from alphadia.workflow.optimizers.targeted import (
@@ -727,15 +728,70 @@ def test_automatic_optimizer_keeps_current_value_on_empty_history():
     # given
     workflow = create_workflow_instance()
     ms2_optimizer = _create_ms2_optimizer_with_empty_batch(workflow)
-    ms2_error_before = workflow.optimization_manager.ms2_error
+    # a value distinct from the initial parameter, so the assertion cannot hold trivially
+    workflow.optimization_manager.update(ms2_error=42.0)
     classifier_version_before = workflow.optimization_manager.classifier_version
 
     # when
     ms2_optimizer._update_workflow()
 
     # then
-    assert workflow.optimization_manager.ms2_error == ms2_error_before
+    assert workflow.optimization_manager.ms2_error == 42.0
     assert workflow.optimization_manager.classifier_version == classifier_version_before
+
+
+def test_automatic_optimizer_step_does_not_propose_parameter_without_measurement():
+    """Tests that a round with no measurement leaves the search parameter unchanged.
+
+    Proposing from an empty frame calibrates the parameter to zero, which would make
+    every later search extract nothing.
+    """
+    # given
+    workflow = create_workflow_instance()
+    ms2_optimizer = _create_ms2_optimizer_with_empty_batch(workflow)
+    workflow.optimization_manager.update(ms2_error=42.0)
+
+    # when
+    ms2_optimizer.step(pd.DataFrame(), pd.DataFrame())
+
+    # then
+    assert ms2_optimizer.history_df.empty
+    assert workflow.optimization_manager.ms2_error == 42.0
+
+
+def test_automatic_optimizer_plot_does_not_raise_on_empty_history():
+    """Tests that plotting an optimizer that recorded nothing warns instead of raising."""
+    # given
+    workflow = create_workflow_instance()
+    ms2_optimizer = _create_ms2_optimizer_with_empty_batch(workflow)
+
+    # when
+    ms2_optimizer.plot()
+
+    # then
+    assert ms2_optimizer.history_df.empty
+
+
+def test_automatic_optimizer_requires_a_declared_feature():
+    """Tests that a subclass forgetting to declare its feature fails at construction."""
+
+    # given
+    class FeaturelessOptimizer(AutomaticOptimizer):
+        pass
+
+    # when / then
+    with pytest.raises(
+        NotImplementedError, match="must declare a class-level _feature"
+    ):
+        FeaturelessOptimizer(
+            100,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
 
 
 def test_automatic_optimizer_proceeds_with_insufficient_precursors_on_empty_batch():

--- a/tests/unit_tests/workflow/test_workflow.py
+++ b/tests/unit_tests/workflow/test_workflow.py
@@ -21,7 +21,6 @@ from alphadia.workflow.optimizers.automatic import (
     AutomaticMobilityOptimizer,
     AutomaticMS1Optimizer,
     AutomaticMS2Optimizer,
-    AutomaticOptimizer,
     AutomaticRTOptimizer,
 )
 from alphadia.workflow.optimizers.targeted import (
@@ -691,7 +690,10 @@ def test_automatic_mobility_optimizer():
 
 
 def _create_ms2_optimizer_with_empty_batch(workflow):
-    """Builds an MS2 optimizer whose optlock reports no elution groups, as after an empty batch."""
+    """Make an MS2 optimizer with an optlock that has no elution group.
+
+    This is the state after a batch that extracted nothing.
+    """
     workflow._optimization_handler._optlock.total_elution_groups = 0
 
     return AutomaticMS2Optimizer(
@@ -706,7 +708,7 @@ def _create_ms2_optimizer_with_empty_batch(workflow):
 
 
 def test_automatic_optimizer_records_no_history_row_for_empty_batch():
-    """Tests that a round without a measurement adds no row to the history."""
+    """Test that a round with no measurement adds no row to the history."""
     # given
     workflow = create_workflow_instance()
     ms2_optimizer = _create_ms2_optimizer_with_empty_batch(workflow)
@@ -724,11 +726,12 @@ def test_automatic_optimizer_records_no_history_row_for_empty_batch():
 
 
 def test_automatic_optimizer_keeps_current_value_on_empty_history():
-    """Tests that updating the workflow from an empty history leaves the optimization manager untouched."""
+    """Test that an update from an empty history does not change the optimization manager."""
     # given
     workflow = create_workflow_instance()
     ms2_optimizer = _create_ms2_optimizer_with_empty_batch(workflow)
-    # a value distinct from the initial parameter, so the assertion cannot hold trivially
+    # use a value that is different from the initial parameter. Then the assertion
+    # cannot become true by accident.
     workflow.optimization_manager.update(ms2_error=42.0)
     classifier_version_before = workflow.optimization_manager.classifier_version
 
@@ -741,10 +744,10 @@ def test_automatic_optimizer_keeps_current_value_on_empty_history():
 
 
 def test_automatic_optimizer_step_does_not_propose_parameter_without_measurement():
-    """Tests that a round with no measurement leaves the search parameter unchanged.
+    """Test that a round with no measurement keeps the search parameter unchanged.
 
-    Proposing from an empty frame calibrates the parameter to zero, which would make
-    every later search extract nothing.
+    A proposal from an empty frame calibrates the parameter to zero. Then all
+    subsequent searches find nothing.
     """
     # given
     workflow = create_workflow_instance()
@@ -760,7 +763,7 @@ def test_automatic_optimizer_step_does_not_propose_parameter_without_measurement
 
 
 def test_automatic_optimizer_plot_does_not_raise_on_empty_history():
-    """Tests that plotting an optimizer that recorded nothing warns instead of raising."""
+    """Test that plot() gives a warning and no error if there is no measurement."""
     # given
     workflow = create_workflow_instance()
     ms2_optimizer = _create_ms2_optimizer_with_empty_batch(workflow)
@@ -772,30 +775,8 @@ def test_automatic_optimizer_plot_does_not_raise_on_empty_history():
     assert ms2_optimizer.history_df.empty
 
 
-def test_automatic_optimizer_requires_a_declared_feature():
-    """Tests that a subclass forgetting to declare its feature fails at construction."""
-
-    # given
-    class FeaturelessOptimizer(AutomaticOptimizer):
-        pass
-
-    # when / then
-    with pytest.raises(
-        NotImplementedError, match="must declare a class-level _feature"
-    ):
-        FeaturelessOptimizer(
-            100,
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-        )
-
-
 def test_automatic_optimizer_proceeds_with_insufficient_precursors_on_empty_batch():
-    """Tests that the graceful-degradation path survives a batch that extracted nothing."""
+    """Test that the recovery path continues after a batch that extracted nothing."""
     # given
     workflow = create_workflow_instance()
     ms2_optimizer = _create_ms2_optimizer_with_empty_batch(workflow)

--- a/tests/unit_tests/workflow/test_workflow.py
+++ b/tests/unit_tests/workflow/test_workflow.py
@@ -689,6 +689,70 @@ def test_automatic_mobility_optimizer():
     assert workflow.optimization_manager.classifier_version == 2
 
 
+def _create_ms2_optimizer_with_empty_batch(workflow):
+    """Builds an MS2 optimizer whose optlock reports no elution groups, as after an empty batch."""
+    workflow._optimization_handler._optlock.total_elution_groups = 0
+
+    return AutomaticMS2Optimizer(
+        100,
+        workflow.config,
+        workflow.optimization_manager,
+        workflow.calibration_manager,
+        workflow._fdr_manager,
+        workflow._optimization_handler._optlock,
+        workflow.reporter,
+    )
+
+
+def test_automatic_optimizer_records_no_history_row_for_empty_batch():
+    """Tests that a round without a measurement adds no row to the history."""
+    # given
+    workflow = create_workflow_instance()
+    ms2_optimizer = _create_ms2_optimizer_with_empty_batch(workflow)
+
+    # when
+    with patch.object(workflow.reporter, "log_string") as mock_log_string:
+        ms2_optimizer._update_history(pd.DataFrame(), pd.DataFrame())
+
+    # then
+    assert ms2_optimizer.history_df.empty
+    assert any(
+        call.kwargs.get("verbosity") == "warning"
+        for call in mock_log_string.call_args_list
+    )
+
+
+def test_automatic_optimizer_keeps_current_value_on_empty_history():
+    """Tests that updating the workflow from an empty history leaves the optimization manager untouched."""
+    # given
+    workflow = create_workflow_instance()
+    ms2_optimizer = _create_ms2_optimizer_with_empty_batch(workflow)
+    ms2_error_before = workflow.optimization_manager.ms2_error
+    classifier_version_before = workflow.optimization_manager.classifier_version
+
+    # when
+    ms2_optimizer._update_workflow()
+
+    # then
+    assert workflow.optimization_manager.ms2_error == ms2_error_before
+    assert workflow.optimization_manager.classifier_version == classifier_version_before
+
+
+def test_automatic_optimizer_proceeds_with_insufficient_precursors_on_empty_batch():
+    """Tests that the graceful-degradation path survives a batch that extracted nothing."""
+    # given
+    workflow = create_workflow_instance()
+    ms2_optimizer = _create_ms2_optimizer_with_empty_batch(workflow)
+    ms2_error_before = workflow.optimization_manager.ms2_error
+
+    # when
+    ms2_optimizer.proceed_with_insufficient_precursors(pd.DataFrame(), pd.DataFrame())
+
+    # then
+    assert ms2_optimizer.history_df.empty
+    assert workflow.optimization_manager.ms2_error == ms2_error_before
+
+
 def test_targeted_ms2_optimizer():
     workflow = create_workflow_instance()
 


### PR DESCRIPTION
A search stops with a `ZeroDivisionError` when an optimization batch extracts nothing. The failure occurs in the code that must recover from a batch with too few precursors.

Three optimizers measure the same quantity. Each one calculated it separately, and none of them handled a batch with no data. This change gives the measurement its own class. The class holds the name, the calculation, and the rule for a batch with no data. All optimizers now use one rule, and a new optimizer gets the rule with it.

A round with no data is left out of the optimization history. The alternative is to record a zero. But zero is also a valid measurement, and it would corrupt the convergence test without an error message.

Optimization keeps the current search parameter when a round gives no data. It also completes normally when no round gives data at all.

A batch with data behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
